### PR TITLE
Add TCP endpoint implementation, schema, sample configs, and tests; update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # hakoniwa-pdu-endpoint
 
-`hakoniwa-pdu-endpoint` is a C++ library that provides a file-based configuration for UDP communication endpoints, designed for Hakoniwa PDU (Protocol Data Unit) communication. It allows for flexible setup of UDP sockets by defining communication parameters in a simple JSON file.
+`hakoniwa-pdu-endpoint` is a C++ library that provides a file-based configuration for UDP/TCP communication endpoints, designed for Hakoniwa PDU (Protocol Data Unit) communication. It allows for flexible setup of sockets by defining communication parameters in a simple JSON file.
 
 ## Features
 
-- **JSON-based Configuration**: Easily configure UDP endpoints, including IP addresses, ports, and various socket options.
+- **JSON-based Configuration**: Easily configure UDP/TCP endpoints, including IP addresses, ports, and various socket options.
 - **Multiple Communication Directions**: Supports `in` (receive-only), `out` (send-only), and `inout` (bidirectional) communication modes.
 - **Dynamic Replies**: In `inout` mode, the endpoint can dynamically reply to the last received client, enabling simple request/response patterns.
 - **Cross-platform**: Built with standard C++ and CMake, making it portable across different operating systems.
@@ -51,7 +51,15 @@ You should see output indicating that all tests have passed.
 
 ## Configuration Example
 
-Configuration is done via a JSON file. The schema can be found in `config/schema/udp_endpoint_schema.json`.
+Configuration is done via a JSON file. The schemas can be found in:
+
+- UDP: `config/schema/udp_endpoint_schema.json`
+- TCP: `config/schema/tcp_endpoint_schema.json`
+
+TCP configurations require a `role` that indicates connection behavior:
+
+- `client`: actively connects to `remote`
+- `server`: listens on `local` and accepts connections
 
 Here is an example of a bidirectional (`inout`) endpoint that listens on port `7000` and can dynamically reply to any client that sends it a message:
 
@@ -74,3 +82,29 @@ Here is an example of a bidirectional (`inout`) endpoint that listens on port `7
 ```
 
 For more examples, please refer to `config/sample/udp_endpoint.json`.
+
+## TCP Configuration Example
+
+Here is an example of a bidirectional TCP client that connects to a server:
+
+**`tcp_config.json`**
+```json
+{
+  "protocol": "tcp",
+  "name": "command_client",
+  "direction": "inout",
+  "role": "client",
+  "remote": {
+    "address": "127.0.0.1",
+    "port": 7777
+  },
+  "options": {
+    "connect_timeout_ms": 2000,
+    "read_timeout_ms": 1000,
+    "write_timeout_ms": 1000,
+    "no_delay": true
+  }
+}
+```
+
+For more examples, please refer to `config/sample/tcp_endpoint.json`.

--- a/config/sample/tcp_endpoint.json
+++ b/config/sample/tcp_endpoint.json
@@ -1,0 +1,115 @@
+// ========================================
+// 例1: シンプルな送信用TCPクライアント
+// ========================================
+{
+  "protocol": "tcp",
+  "name": "sensor_client",
+  "direction": "out",
+  "role": "client",
+  "remote": {
+    "address": "192.168.1.100",
+    "port": 8080
+  }
+}
+
+
+// ========================================
+// 例2: 受信用TCPサーバ（詳細設定）
+// ========================================
+{
+  "protocol": "tcp",
+  "name": "sensor_server",
+  "direction": "in",
+  "role": "server",
+  "local": {
+    "address": "0.0.0.0",
+    "port": 9000
+  },
+  "options": {
+    "backlog": 20,
+    "reuse_address": true,
+    "keepalive": true,
+    "no_delay": true
+  }
+}
+
+
+// ========================================
+// 例3: 双方向エンドポイント（サーバ/accept側）
+// ========================================
+{
+  "protocol": "tcp",
+  "name": "command_server",
+  "direction": "inout",
+  "role": "server",
+  "local": {
+    "address": "0.0.0.0",
+    "port": 7000
+  },
+  "options": {
+    "read_timeout_ms": 1000,
+    "write_timeout_ms": 1000
+  }
+}
+
+
+// ========================================
+// 例4: 双方向エンドポイント（クライアント/接続開始側）
+// ========================================
+{
+  "protocol": "tcp",
+  "name": "command_client",
+  "direction": "inout",
+  "role": "client",
+  "remote": {
+    "address": "192.168.1.50",
+    "port": 7777
+  },
+  "options": {
+    "connect_timeout_ms": 2000,
+    "read_timeout_ms": 1000,
+    "write_timeout_ms": 1000
+  }
+}
+
+
+// ========================================
+// 例5: 低遅延の制御ストリーム
+// ========================================
+{
+  "protocol": "tcp",
+  "name": "low_latency_stream",
+  "direction": "out",
+  "role": "client",
+  "remote": {
+    "address": "10.0.0.10",
+    "port": 5001
+  },
+  "options": {
+    "no_delay": true,
+    "send_buffer_size": 16384,
+    "recv_buffer_size": 16384
+  }
+}
+
+
+// ========================================
+// 例6: ローカルホスト通信（テスト用）
+// ========================================
+{
+  "protocol": "tcp",
+  "name": "localhost_test",
+  "direction": "inout",
+  "role": "client",
+  "remote": {
+    "address": "127.0.0.1",
+    "port": 12345
+  },
+  "options": {
+    "blocking": true,
+    "linger": {
+      "enabled": true,
+      "timeout_sec": 2
+    }
+  }
+}

--- a/config/schema/tcp_endpoint_schema.json
+++ b/config/schema/tcp_endpoint_schema.json
@@ -1,0 +1,176 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "TCP Endpoint Configuration",
+  "description": "TCP通信エンドポイントの設定",
+  "type": "object",
+  "required": ["protocol", "name", "direction"],
+  "properties": {
+    "protocol": {
+      "type": "string",
+      "enum": ["tcp"],
+      "description": "プロトコルタイプ（TCP固定）"
+    },
+    "name": {
+      "type": "string",
+      "description": "エンドポイント名",
+      "minLength": 1,
+      "maxLength": 256,
+      "examples": ["sensor_stream", "control_client"]
+    },
+    "direction": {
+      "type": "string",
+      "enum": ["in", "out", "inout"],
+      "description": "通信方向"
+    },
+    "role": {
+      "type": "string",
+      "enum": ["client", "server"],
+      "description": "接続役割（client: 接続開始, server: accept待ち）"
+    },
+
+    "local": { "$ref": "#/$defs/endpoint" },
+    "remote": {
+      "$ref": "#/$defs/endpoint",
+      "description": "接続先（clientの場合に指定）"
+    },
+
+    "options": {
+      "type": "object",
+      "description": "オプション設定",
+      "properties": {
+        "backlog": {
+          "type": "integer",
+          "description": "サーバ受け入れキュー長（listen）",
+          "minimum": 1,
+          "maximum": 1024,
+          "default": 5
+        },
+        "connect_timeout_ms": {
+          "type": "integer",
+          "description": "接続タイムアウト（ミリ秒）",
+          "minimum": 0,
+          "default": 1000
+        },
+        "read_timeout_ms": {
+          "type": "integer",
+          "description": "受信タイムアウト（ミリ秒）",
+          "minimum": 0,
+          "default": 1000
+        },
+        "write_timeout_ms": {
+          "type": "integer",
+          "description": "送信タイムアウト（ミリ秒）",
+          "minimum": 0,
+          "default": 1000
+        },
+        "blocking": {
+          "type": "boolean",
+          "description": "ブロッキングモード",
+          "default": true
+        },
+        "reuse_address": {
+          "type": "boolean",
+          "description": "SO_REUSEADDRオプション",
+          "default": true
+        },
+        "keepalive": {
+          "type": "boolean",
+          "description": "TCP keepalive 有効化",
+          "default": true
+        },
+        "no_delay": {
+          "type": "boolean",
+          "description": "Nagleアルゴリズム無効化（TCP_NODELAY）",
+          "default": true
+        },
+        "recv_buffer_size": {
+          "type": "integer",
+          "description": "受信バッファサイズ（バイト）",
+          "minimum": 512,
+          "maximum": 1048576,
+          "default": 8192
+        },
+        "send_buffer_size": {
+          "type": "integer",
+          "description": "送信バッファサイズ（バイト）",
+          "minimum": 512,
+          "maximum": 1048576,
+          "default": 8192
+        },
+        "linger": {
+          "type": "object",
+          "description": "SO_LINGERオプション",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "linger 有効化",
+              "default": false
+            },
+            "timeout_sec": {
+              "type": "integer",
+              "description": "linger タイムアウト（秒）",
+              "minimum": 0,
+              "default": 0
+            }
+          },
+          "required": ["enabled"],
+          "if": { "properties": { "enabled": { "const": true } } },
+          "then": { "required": ["timeout_sec"] }
+        }
+      }
+    }
+  },
+
+  "allOf": [
+    {
+      "if": { "properties": { "direction": { "const": "in" } } },
+      "then": {
+        "required": ["local"],
+        "properties": { "role": { "const": "server" } }
+      }
+    },
+    {
+      "if": { "properties": { "direction": { "const": "out" } } },
+      "then": {
+        "required": ["remote"],
+        "properties": { "role": { "const": "client" } }
+      }
+    },
+    {
+      "if": { "properties": { "direction": { "const": "inout" } } },
+      "then": { "required": ["role"] }
+    },
+    {
+      "if": { "properties": { "role": { "const": "server" } } },
+      "then": { "required": ["local"], "not": { "required": ["remote"] } }
+    },
+    {
+      "if": { "properties": { "role": { "const": "client" } } },
+      "then": { "required": ["remote"], "not": { "required": ["local"] } }
+    }
+  ],
+
+  "$defs": {
+    "endpoint": {
+      "type": "object",
+      "required": ["address", "port"],
+      "properties": {
+        "address": {
+          "type": "string",
+          "description": "IPアドレス（IPv4またはIPv6）",
+          "oneOf": [
+            { "format": "ipv4", "examples": ["192.168.1.100", "127.0.0.1"] },
+            { "format": "ipv6", "examples": ["::1", "fe80::1"] }
+          ]
+        },
+        "port": {
+          "type": "integer",
+          "description": "ポート番号",
+          "minimum": 1,
+          "maximum": 65535,
+          "examples": [8080, 9000]
+        }
+      }
+    }
+  }
+}

--- a/include/hakoniwa/pdu/socket_utils.hpp
+++ b/include/hakoniwa/pdu/socket_utils.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "hakoniwa/pdu/endpoint_types.h"
+#include <netdb.h>
+#include <nlohmann/json.hpp>
+#include <string>
+
+namespace hakoniwa {
+namespace pdu {
+
+HakoPduErrorType map_errno_to_error(int error_number) noexcept;
+HakoPduEndpointDirectionType parse_direction(const std::string& direction);
+HakoPduErrorType resolve_address(const nlohmann::json& endpoint_json, int socket_type, addrinfo** res);
+
+}  // namespace pdu
+}  // namespace hakoniwa

--- a/include/hakoniwa/pdu/tcp_endpoint.hpp
+++ b/include/hakoniwa/pdu/tcp_endpoint.hpp
@@ -1,0 +1,63 @@
+#pragma once
+
+#include "hakoniwa/pdu/endpoint.hpp"
+#include <netinet/in.h>
+#include <string>
+
+namespace hakoniwa {
+namespace pdu {
+
+class TcpEndpoint final : public Endpoint
+{
+public:
+    TcpEndpoint(const std::string& name, HakoPduEndpointDirectionType type);
+
+    HakoPduErrorType open(const std::string& config_path) override;
+    HakoPduErrorType close() noexcept override;
+    HakoPduErrorType start() noexcept override;
+    HakoPduErrorType stop() noexcept override;
+    HakoPduErrorType is_running(bool& running) noexcept override;
+    HakoPduErrorType send(const void* data, size_t size) noexcept override;
+    HakoPduErrorType recv(void* data, size_t buffer_size, size_t& received_size) noexcept override;
+
+private:
+    enum class Role {
+        Client,
+        Server
+    };
+
+    struct Options {
+        int backlog = 5;
+        int connect_timeout_ms = 1000;
+        int read_timeout_ms = 1000;
+        int write_timeout_ms = 1000;
+        bool blocking = true;
+        bool reuse_address = true;
+        bool keepalive = true;
+        bool no_delay = true;
+        int recv_buffer_size = 8192;
+        int send_buffer_size = 8192;
+        bool linger_enabled = false;
+        int linger_timeout_sec = 0;
+    };
+
+    HakoPduErrorType configure_socket_options(int fd, const Options& options) noexcept;
+    HakoPduErrorType configure_timeouts(int fd, const Options& options) noexcept;
+    HakoPduErrorType connect_with_timeout(int fd, addrinfo* remote_addr, const Options& options) noexcept;
+    HakoPduErrorType accept_client() noexcept;
+    HakoPduErrorType ensure_connected() noexcept;
+
+    int listen_fd_ = -1;
+    int socket_fd_ = -1;
+    bool running_ = false;
+    HakoPduEndpointDirectionType config_direction_ = HAKO_PDU_ENDPOINT_DIRECTION_INOUT;
+    Role role_ = Role::Client;
+    Options options_{};
+    sockaddr_storage local_addr_{};
+    socklen_t local_addr_len_ = 0;
+    sockaddr_storage remote_addr_{};
+    socklen_t remote_addr_len_ = 0;
+};
+
+}  // namespace pdu
+}  // namespace hakoniwa

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,7 +16,9 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(nlohmann_json)
 
 add_library(hakoniwa_pdu_endpoint
+  socket_utils.cpp
   udp_endpoint.cpp
+  tcp_endpoint.cpp
 )
 
 target_include_directories(hakoniwa_pdu_endpoint

--- a/src/socket_utils.cpp
+++ b/src/socket_utils.cpp
@@ -1,0 +1,48 @@
+#include "hakoniwa/pdu/socket_utils.hpp"
+
+#include <netdb.h>
+
+namespace hakoniwa {
+namespace pdu {
+
+HakoPduErrorType map_errno_to_error(int error_number) noexcept
+{
+    if (error_number == EAGAIN || error_number == EWOULDBLOCK) {
+        return HAKO_PDU_ERR_TIMEOUT;
+    }
+    return HAKO_PDU_ERR_IO_ERROR;
+}
+
+HakoPduEndpointDirectionType parse_direction(const std::string& direction)
+{
+    if (direction == "in") {
+        return HAKO_PDU_ENDPOINT_DIRECTION_IN;
+    }
+    if (direction == "out") {
+        return HAKO_PDU_ENDPOINT_DIRECTION_OUT;
+    }
+    return HAKO_PDU_ENDPOINT_DIRECTION_INOUT;
+}
+
+HakoPduErrorType resolve_address(const nlohmann::json& endpoint_json, int socket_type, addrinfo** res)
+{
+    if (!endpoint_json.contains("address") || !endpoint_json.contains("port")) {
+        return HAKO_PDU_ERR_INVALID_ARGUMENT;
+    }
+    const std::string address = endpoint_json.at("address").get<std::string>();
+    const int port = endpoint_json.at("port").get<int>();
+    const std::string port_str = std::to_string(port);
+
+    addrinfo hints{};
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = socket_type;
+    hints.ai_flags = AI_NUMERICHOST | AI_PASSIVE;
+
+    if (getaddrinfo(address.c_str(), port_str.c_str(), &hints, res) != 0 || *res == nullptr) {
+        return HAKO_PDU_ERR_INVALID_ARGUMENT;
+    }
+    return HAKO_PDU_ERR_OK;
+}
+
+}  // namespace pdu
+}  // namespace hakoniwa

--- a/src/tcp_endpoint.cpp
+++ b/src/tcp_endpoint.cpp
@@ -1,0 +1,456 @@
+#include "hakoniwa/pdu/tcp_endpoint.hpp"
+
+#include "hakoniwa/pdu/socket_utils.hpp"
+#include <arpa/inet.h>
+#include <cerrno>
+#include <cstring>
+#include <fcntl.h>
+#include <fstream>
+#include <netinet/tcp.h>
+#include <nlohmann/json.hpp>
+#include <poll.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+namespace hakoniwa {
+namespace pdu {
+
+namespace {
+constexpr int kTcpSocketType = SOCK_STREAM;
+}  // namespace
+
+TcpEndpoint::TcpEndpoint(const std::string& name, HakoPduEndpointDirectionType type)
+    : Endpoint(name, type) {}
+
+HakoPduErrorType TcpEndpoint::open(const std::string& config_path)
+{
+    if (socket_fd_ != -1 || listen_fd_ != -1) {
+        return HAKO_PDU_ERR_BUSY;
+    }
+
+    std::ifstream config_stream(config_path);
+    if (!config_stream) {
+        return HAKO_PDU_ERR_IO_ERROR;
+    }
+
+    nlohmann::json config_json;
+    try {
+        config_stream >> config_json;
+    } catch (const nlohmann::json::exception&) {
+        return HAKO_PDU_ERR_INVALID_ARGUMENT;
+    }
+
+    if (!config_json.contains("protocol") || config_json.at("protocol").get<std::string>() != "tcp") {
+        return HAKO_PDU_ERR_INVALID_ARGUMENT;
+    }
+    if (!config_json.contains("direction") || !config_json.contains("role")) {
+        return HAKO_PDU_ERR_INVALID_ARGUMENT;
+    }
+
+    config_direction_ = parse_direction(config_json.at("direction").get<std::string>());
+    const std::string role_value = config_json.at("role").get<std::string>();
+    if (role_value == "server") {
+        role_ = Role::Server;
+    } else if (role_value == "client") {
+        role_ = Role::Client;
+    } else {
+        return HAKO_PDU_ERR_INVALID_ARGUMENT;
+    }
+
+    addrinfo* local_addr_info = nullptr;
+    addrinfo* remote_addr_info = nullptr;
+
+    if (role_ == Role::Server) {
+        if (!config_json.contains("local")) {
+            return HAKO_PDU_ERR_INVALID_ARGUMENT;
+        }
+        if (resolve_address(config_json.at("local"), kTcpSocketType, &local_addr_info) != HAKO_PDU_ERR_OK) {
+            return HAKO_PDU_ERR_INVALID_ARGUMENT;
+        }
+    }
+    if (role_ == Role::Client) {
+        if (!config_json.contains("remote")) {
+            return HAKO_PDU_ERR_INVALID_ARGUMENT;
+        }
+        if (resolve_address(config_json.at("remote"), kTcpSocketType, &remote_addr_info) != HAKO_PDU_ERR_OK) {
+            return HAKO_PDU_ERR_INVALID_ARGUMENT;
+        }
+    }
+
+    if (config_json.contains("options")) {
+        const auto& opts = config_json.at("options");
+        options_.backlog = opts.value("backlog", options_.backlog);
+        options_.connect_timeout_ms = opts.value("connect_timeout_ms", options_.connect_timeout_ms);
+        options_.read_timeout_ms = opts.value("read_timeout_ms", options_.read_timeout_ms);
+        options_.write_timeout_ms = opts.value("write_timeout_ms", options_.write_timeout_ms);
+        options_.blocking = opts.value("blocking", options_.blocking);
+        options_.reuse_address = opts.value("reuse_address", options_.reuse_address);
+        options_.keepalive = opts.value("keepalive", options_.keepalive);
+        options_.no_delay = opts.value("no_delay", options_.no_delay);
+        options_.recv_buffer_size = opts.value("recv_buffer_size", options_.recv_buffer_size);
+        options_.send_buffer_size = opts.value("send_buffer_size", options_.send_buffer_size);
+        if (opts.contains("linger")) {
+            const auto& linger_opts = opts.at("linger");
+            options_.linger_enabled = linger_opts.value("enabled", options_.linger_enabled);
+            options_.linger_timeout_sec = linger_opts.value("timeout_sec", options_.linger_timeout_sec);
+        }
+    }
+
+    addrinfo* initial_addr = local_addr_info ? local_addr_info : remote_addr_info;
+    if (!initial_addr) {
+        return HAKO_PDU_ERR_INVALID_ARGUMENT;
+    }
+
+    if (role_ == Role::Server) {
+        listen_fd_ = ::socket(initial_addr->ai_family, initial_addr->ai_socktype, initial_addr->ai_protocol);
+        if (listen_fd_ < 0) {
+            if (local_addr_info) freeaddrinfo(local_addr_info);
+            if (remote_addr_info) freeaddrinfo(remote_addr_info);
+            return HAKO_PDU_ERR_IO_ERROR;
+        }
+        if (configure_socket_options(listen_fd_, options_) != HAKO_PDU_ERR_OK) {
+            close();
+            if (local_addr_info) freeaddrinfo(local_addr_info);
+            if (remote_addr_info) freeaddrinfo(remote_addr_info);
+            return HAKO_PDU_ERR_IO_ERROR;
+        }
+        if (::bind(listen_fd_, local_addr_info->ai_addr, local_addr_info->ai_addrlen) != 0) {
+            if (local_addr_info) freeaddrinfo(local_addr_info);
+            if (remote_addr_info) freeaddrinfo(remote_addr_info);
+            close();
+            return HAKO_PDU_ERR_IO_ERROR;
+        }
+        if (::listen(listen_fd_, options_.backlog) != 0) {
+            if (local_addr_info) freeaddrinfo(local_addr_info);
+            if (remote_addr_info) freeaddrinfo(remote_addr_info);
+            close();
+            return HAKO_PDU_ERR_IO_ERROR;
+        }
+        std::memcpy(&local_addr_, local_addr_info->ai_addr, local_addr_info->ai_addrlen);
+        local_addr_len_ = local_addr_info->ai_addrlen;
+    } else {
+        socket_fd_ = ::socket(initial_addr->ai_family, initial_addr->ai_socktype, initial_addr->ai_protocol);
+        if (socket_fd_ < 0) {
+            if (local_addr_info) freeaddrinfo(local_addr_info);
+            if (remote_addr_info) freeaddrinfo(remote_addr_info);
+            return HAKO_PDU_ERR_IO_ERROR;
+        }
+        if (configure_socket_options(socket_fd_, options_) != HAKO_PDU_ERR_OK) {
+            close();
+            if (local_addr_info) freeaddrinfo(local_addr_info);
+            if (remote_addr_info) freeaddrinfo(remote_addr_info);
+            return HAKO_PDU_ERR_IO_ERROR;
+        }
+        if (connect_with_timeout(socket_fd_, remote_addr_info, options_) != HAKO_PDU_ERR_OK) {
+            close();
+            if (local_addr_info) freeaddrinfo(local_addr_info);
+            if (remote_addr_info) freeaddrinfo(remote_addr_info);
+            return HAKO_PDU_ERR_IO_ERROR;
+        }
+        std::memcpy(&remote_addr_, remote_addr_info->ai_addr, remote_addr_info->ai_addrlen);
+        remote_addr_len_ = remote_addr_info->ai_addrlen;
+    }
+
+    if (local_addr_info) freeaddrinfo(local_addr_info);
+    if (remote_addr_info) freeaddrinfo(remote_addr_info);
+
+    running_ = false;
+    return HAKO_PDU_ERR_OK;
+}
+
+HakoPduErrorType TcpEndpoint::close() noexcept
+{
+    running_ = false;
+    if (socket_fd_ >= 0) {
+        ::close(socket_fd_);
+        socket_fd_ = -1;
+    }
+    if (listen_fd_ >= 0) {
+        ::close(listen_fd_);
+        listen_fd_ = -1;
+    }
+    local_addr_len_ = 0;
+    remote_addr_len_ = 0;
+    return HAKO_PDU_ERR_OK;
+}
+
+HakoPduErrorType TcpEndpoint::start() noexcept
+{
+    if (role_ == Role::Server) {
+        if (listen_fd_ < 0) {
+            return HAKO_PDU_ERR_INVALID_ARGUMENT;
+        }
+    } else if (socket_fd_ < 0) {
+        return HAKO_PDU_ERR_INVALID_ARGUMENT;
+    }
+    running_ = true;
+    return HAKO_PDU_ERR_OK;
+}
+
+HakoPduErrorType TcpEndpoint::stop() noexcept
+{
+    running_ = false;
+    return HAKO_PDU_ERR_OK;
+}
+
+HakoPduErrorType TcpEndpoint::is_running(bool& running) noexcept
+{
+    running = running_;
+    return HAKO_PDU_ERR_OK;
+}
+
+HakoPduErrorType TcpEndpoint::send(const void* data, size_t size) noexcept
+{
+    if (data == nullptr || size == 0) {
+        return HAKO_PDU_ERR_INVALID_ARGUMENT;
+    }
+    if (config_direction_ == HAKO_PDU_ENDPOINT_DIRECTION_IN) {
+        return HAKO_PDU_ERR_INVALID_ARGUMENT;
+    }
+
+    HakoPduErrorType connect_result = ensure_connected();
+    if (connect_result != HAKO_PDU_ERR_OK) {
+        return connect_result;
+    }
+
+    size_t total_sent = 0;
+    const auto* buffer = static_cast<const char*>(data);
+    while (total_sent < size) {
+        ssize_t sent = ::send(socket_fd_, buffer + total_sent, size - total_sent, 0);
+        if (sent > 0) {
+            total_sent += static_cast<size_t>(sent);
+            continue;
+        }
+        if (sent == 0) {
+            return HAKO_PDU_ERR_IO_ERROR;
+        }
+        if (errno == EBUSY || errno == EAGAIN || errno == EWOULDBLOCK) {
+            continue;
+        }
+        return map_errno_to_error(errno);
+    }
+    return HAKO_PDU_ERR_OK;
+}
+
+HakoPduErrorType TcpEndpoint::recv(void* data, size_t buffer_size, size_t& received_size) noexcept
+{
+    received_size = 0;
+    if (data == nullptr || buffer_size == 0) {
+        return HAKO_PDU_ERR_INVALID_ARGUMENT;
+    }
+    if (config_direction_ == HAKO_PDU_ENDPOINT_DIRECTION_OUT) {
+        return HAKO_PDU_ERR_INVALID_ARGUMENT;
+    }
+
+    HakoPduErrorType connect_result = ensure_connected();
+    if (connect_result != HAKO_PDU_ERR_OK) {
+        return connect_result;
+    }
+
+    size_t total_received = 0;
+    auto* buffer = static_cast<char*>(data);
+    while (total_received < buffer_size) {
+        ssize_t received = ::recv(socket_fd_, buffer + total_received, buffer_size - total_received, 0);
+        if (received > 0) {
+            total_received += static_cast<size_t>(received);
+            continue;
+        }
+        if (received == 0) {
+            received_size = total_received;
+            return HAKO_PDU_ERR_IO_ERROR;
+        }
+        if (errno == EBUSY || errno == EAGAIN || errno == EWOULDBLOCK) {
+            continue;
+        }
+        received_size = total_received;
+        return map_errno_to_error(errno);
+    }
+
+    received_size = total_received;
+    return HAKO_PDU_ERR_OK;
+}
+
+HakoPduErrorType TcpEndpoint::configure_socket_options(int fd, const Options& options) noexcept
+{
+    if (options.reuse_address) {
+        int reuse = 1;
+        if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse)) != 0) {
+            return HAKO_PDU_ERR_IO_ERROR;
+        }
+    }
+
+    if (options.keepalive) {
+        int keepalive = 1;
+        if (setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, &keepalive, sizeof(keepalive)) != 0) {
+            return HAKO_PDU_ERR_IO_ERROR;
+        }
+    }
+
+    if (options.no_delay) {
+        int nodelay = 1;
+        if (setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &nodelay, sizeof(nodelay)) != 0) {
+            return HAKO_PDU_ERR_IO_ERROR;
+        }
+    }
+
+    if (options.recv_buffer_size > 0) {
+        if (setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &options.recv_buffer_size, sizeof(options.recv_buffer_size)) != 0) {
+            return HAKO_PDU_ERR_IO_ERROR;
+        }
+    }
+
+    if (options.send_buffer_size > 0) {
+        if (setsockopt(fd, SOL_SOCKET, SO_SNDBUF, &options.send_buffer_size, sizeof(options.send_buffer_size)) != 0) {
+            return HAKO_PDU_ERR_IO_ERROR;
+        }
+    }
+
+    if (options.linger_enabled) {
+        linger linger_opts{};
+        linger_opts.l_onoff = 1;
+        linger_opts.l_linger = options.linger_timeout_sec;
+        if (setsockopt(fd, SOL_SOCKET, SO_LINGER, &linger_opts, sizeof(linger_opts)) != 0) {
+            return HAKO_PDU_ERR_IO_ERROR;
+        }
+    }
+
+    return configure_timeouts(fd, options);
+}
+
+HakoPduErrorType TcpEndpoint::configure_timeouts(int fd, const Options& options) noexcept
+{
+    if (options.read_timeout_ms >= 0) {
+        timeval timeout{};
+        timeout.tv_sec = options.read_timeout_ms / 1000;
+        timeout.tv_usec = (options.read_timeout_ms % 1000) * 1000;
+        if (setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout)) != 0) {
+            return HAKO_PDU_ERR_IO_ERROR;
+        }
+    }
+    if (options.write_timeout_ms >= 0) {
+        timeval timeout{};
+        timeout.tv_sec = options.write_timeout_ms / 1000;
+        timeout.tv_usec = (options.write_timeout_ms % 1000) * 1000;
+        if (setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &timeout, sizeof(timeout)) != 0) {
+            return HAKO_PDU_ERR_IO_ERROR;
+        }
+    }
+
+    if (!options.blocking) {
+        int flags = fcntl(fd, F_GETFL, 0);
+        if (flags < 0 || fcntl(fd, F_SETFL, flags | O_NONBLOCK) != 0) {
+            return HAKO_PDU_ERR_IO_ERROR;
+        }
+    }
+
+    return HAKO_PDU_ERR_OK;
+}
+
+HakoPduErrorType TcpEndpoint::connect_with_timeout(int fd, addrinfo* remote_addr, const Options& options) noexcept
+{
+    if (!remote_addr) {
+        return HAKO_PDU_ERR_INVALID_ARGUMENT;
+    }
+
+    bool restore_blocking = options.blocking;
+    if (options.connect_timeout_ms > 0) {
+        int flags = fcntl(fd, F_GETFL, 0);
+        if (flags < 0) {
+            return HAKO_PDU_ERR_IO_ERROR;
+        }
+        if (fcntl(fd, F_SETFL, flags | O_NONBLOCK) != 0) {
+            return HAKO_PDU_ERR_IO_ERROR;
+        }
+
+        int connect_result = ::connect(fd, remote_addr->ai_addr, remote_addr->ai_addrlen);
+        if (connect_result == 0) {
+            if (restore_blocking) {
+                fcntl(fd, F_SETFL, flags);
+            }
+            return HAKO_PDU_ERR_OK;
+        }
+        if (errno != EINPROGRESS) {
+            return HAKO_PDU_ERR_IO_ERROR;
+        }
+
+        pollfd poll_fd{};
+        poll_fd.fd = fd;
+        poll_fd.events = POLLOUT;
+        int poll_result = ::poll(&poll_fd, 1, options.connect_timeout_ms);
+        if (poll_result <= 0) {
+            return HAKO_PDU_ERR_TIMEOUT;
+        }
+
+        int so_error = 0;
+        socklen_t so_error_len = sizeof(so_error);
+        if (getsockopt(fd, SOL_SOCKET, SO_ERROR, &so_error, &so_error_len) != 0 || so_error != 0) {
+            return HAKO_PDU_ERR_IO_ERROR;
+        }
+
+        if (restore_blocking) {
+            fcntl(fd, F_SETFL, flags);
+        }
+
+        return HAKO_PDU_ERR_OK;
+    }
+
+    if (::connect(fd, remote_addr->ai_addr, remote_addr->ai_addrlen) != 0) {
+        return HAKO_PDU_ERR_IO_ERROR;
+    }
+    return HAKO_PDU_ERR_OK;
+}
+
+HakoPduErrorType TcpEndpoint::accept_client() noexcept
+{
+    if (listen_fd_ < 0) {
+        return HAKO_PDU_ERR_INVALID_ARGUMENT;
+    }
+
+    if (socket_fd_ >= 0) {
+        return HAKO_PDU_ERR_OK;
+    }
+
+    if (options_.read_timeout_ms >= 0) {
+        pollfd poll_fd{};
+        poll_fd.fd = listen_fd_;
+        poll_fd.events = POLLIN;
+        int poll_result = ::poll(&poll_fd, 1, options_.read_timeout_ms);
+        if (poll_result == 0) {
+            return HAKO_PDU_ERR_TIMEOUT;
+        }
+        if (poll_result < 0) {
+            return HAKO_PDU_ERR_IO_ERROR;
+        }
+    }
+
+    sockaddr_storage client_addr{};
+    socklen_t client_len = sizeof(client_addr);
+    int client_fd = ::accept(listen_fd_, reinterpret_cast<sockaddr*>(&client_addr), &client_len);
+    if (client_fd < 0) {
+        return map_errno_to_error(errno);
+    }
+
+    if (configure_socket_options(client_fd, options_) != HAKO_PDU_ERR_OK) {
+        ::close(client_fd);
+        return HAKO_PDU_ERR_IO_ERROR;
+    }
+
+    socket_fd_ = client_fd;
+    return HAKO_PDU_ERR_OK;
+}
+
+HakoPduErrorType TcpEndpoint::ensure_connected() noexcept
+{
+    if (role_ == Role::Server) {
+        return accept_client();
+    }
+
+    if (socket_fd_ < 0) {
+        return HAKO_PDU_ERR_INVALID_ARGUMENT;
+    }
+    return HAKO_PDU_ERR_OK;
+}
+
+}  // namespace pdu
+}  // namespace hakoniwa

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,3 +17,15 @@ target_link_libraries(udp_endpoint_test
 
 # add_test を使ってテスト実行ファイルを登録
 add_test(NAME udp_endpoint_test COMMAND udp_endpoint_test)
+
+add_executable(tcp_endpoint_test
+  tcp_endpoint_test.cpp
+)
+
+target_link_libraries(tcp_endpoint_test
+  PRIVATE
+    hakoniwa_pdu_endpoint
+    GTest::gtest_main
+)
+
+add_test(NAME tcp_endpoint_test COMMAND tcp_endpoint_test)

--- a/test/tcp_endpoint_test.cpp
+++ b/test/tcp_endpoint_test.cpp
@@ -1,0 +1,149 @@
+#include "hakoniwa/pdu/tcp_endpoint.hpp"
+#include <gtest/gtest.h>
+#include <fstream>
+#include <unistd.h>
+#include <string>
+#include <vector>
+#include <thread>
+#include <chrono>
+
+// Helper to find an available TCP port
+int find_available_tcp_port() {
+    int sock = socket(AF_INET, SOCK_STREAM, 0);
+    if (sock < 0) return -1;
+
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = INADDR_ANY;
+    addr.sin_port = 0;
+
+    if (bind(sock, reinterpret_cast<struct sockaddr*>(&addr), sizeof(addr)) < 0) {
+        close(sock);
+        return -1;
+    }
+
+    socklen_t addr_len = sizeof(addr);
+    if (getsockname(sock, reinterpret_cast<struct sockaddr*>(&addr), &addr_len) < 0) {
+        close(sock);
+        return -1;
+    }
+
+    int port = ntohs(addr.sin_port);
+    close(sock);
+    return port;
+}
+
+// Helper to create a temporary config file
+void create_config_file(const std::string& filepath, const std::string& content) {
+    std::ofstream file(filepath);
+    file << content;
+    file.close();
+}
+
+class TcpEndpointTest : public ::testing::Test {
+protected:
+    std::string server_config_path = "tcp_server_config.json";
+    std::string client_config_path = "tcp_client_config.json";
+    int server_port = -1;
+
+    void SetUp() override {
+        server_port = find_available_tcp_port();
+        ASSERT_NE(server_port, -1);
+    }
+
+    void TearDown() override {
+        unlink(server_config_path.c_str());
+        unlink(client_config_path.c_str());
+    }
+};
+
+TEST_F(TcpEndpointTest, InOutCommunicationServerClient) {
+    std::string server_config = R"({
+        "protocol": "tcp",
+        "name": "server",
+        "direction": "inout",
+        "role": "server",
+        "local": { "address": "127.0.0.1", "port": )" + std::to_string(server_port) + R"( }
+    })";
+    create_config_file(server_config_path, server_config);
+
+    std::string client_config = R"({
+        "protocol": "tcp",
+        "name": "client",
+        "direction": "inout",
+        "role": "client",
+        "remote": { "address": "127.0.0.1", "port": )" + std::to_string(server_port) + R"( }
+    })";
+    create_config_file(client_config_path, client_config);
+
+    hakoniwa::pdu::TcpEndpoint server("server", HAKO_PDU_ENDPOINT_DIRECTION_INOUT);
+    hakoniwa::pdu::TcpEndpoint client("client", HAKO_PDU_ENDPOINT_DIRECTION_INOUT);
+
+    ASSERT_EQ(server.open(server_config_path), HAKO_PDU_ERR_OK);
+    ASSERT_EQ(client.open(client_config_path), HAKO_PDU_ERR_OK);
+    ASSERT_EQ(server.start(), HAKO_PDU_ERR_OK);
+    ASSERT_EQ(client.start(), HAKO_PDU_ERR_OK);
+
+    const std::string ping = "ping";
+    ASSERT_EQ(client.send(ping.c_str(), ping.size()), HAKO_PDU_ERR_OK);
+
+    std::vector<char> server_buffer(ping.size());
+    size_t server_received_size = 0;
+    ASSERT_EQ(server.recv(server_buffer.data(), server_buffer.size(), server_received_size), HAKO_PDU_ERR_OK);
+    ASSERT_EQ(server_received_size, ping.size());
+    ASSERT_EQ(std::string(server_buffer.data(), server_received_size), ping);
+
+    const std::string pong = "pong";
+    ASSERT_EQ(server.send(pong.c_str(), pong.size()), HAKO_PDU_ERR_OK);
+
+    std::vector<char> client_buffer(pong.size());
+    size_t client_received_size = 0;
+    ASSERT_EQ(client.recv(client_buffer.data(), client_buffer.size(), client_received_size), HAKO_PDU_ERR_OK);
+    ASSERT_EQ(client_received_size, pong.size());
+    ASSERT_EQ(std::string(client_buffer.data(), client_received_size), pong);
+
+    ASSERT_EQ(server.stop(), HAKO_PDU_ERR_OK);
+    ASSERT_EQ(client.stop(), HAKO_PDU_ERR_OK);
+    ASSERT_EQ(server.close(), HAKO_PDU_ERR_OK);
+    ASSERT_EQ(client.close(), HAKO_PDU_ERR_OK);
+}
+
+TEST_F(TcpEndpointTest, OutInCommunication) {
+    std::string server_config = R"({
+        "protocol": "tcp",
+        "name": "receiver",
+        "direction": "in",
+        "role": "server",
+        "local": { "address": "127.0.0.1", "port": )" + std::to_string(server_port) + R"( }
+    })";
+    create_config_file(server_config_path, server_config);
+
+    std::string client_config = R"({
+        "protocol": "tcp",
+        "name": "sender",
+        "direction": "out",
+        "role": "client",
+        "remote": { "address": "127.0.0.1", "port": )" + std::to_string(server_port) + R"( }
+    })";
+    create_config_file(client_config_path, client_config);
+
+    hakoniwa::pdu::TcpEndpoint receiver("receiver", HAKO_PDU_ENDPOINT_DIRECTION_IN);
+    hakoniwa::pdu::TcpEndpoint sender("sender", HAKO_PDU_ENDPOINT_DIRECTION_OUT);
+
+    ASSERT_EQ(receiver.open(server_config_path), HAKO_PDU_ERR_OK);
+    ASSERT_EQ(sender.open(client_config_path), HAKO_PDU_ERR_OK);
+    ASSERT_EQ(receiver.start(), HAKO_PDU_ERR_OK);
+    ASSERT_EQ(sender.start(), HAKO_PDU_ERR_OK);
+
+    const std::string data = "test_data";
+    ASSERT_EQ(sender.send(data.c_str(), data.size()), HAKO_PDU_ERR_OK);
+
+    std::vector<char> buffer(data.size());
+    size_t received_size = 0;
+    ASSERT_EQ(receiver.recv(buffer.data(), buffer.size(), received_size), HAKO_PDU_ERR_OK);
+    ASSERT_EQ(received_size, data.size());
+    ASSERT_EQ(std::string(buffer.data(), received_size), data);
+
+    ASSERT_EQ(receiver.close(), HAKO_PDU_ERR_OK);
+    ASSERT_EQ(sender.close(), HAKO_PDU_ERR_OK);
+}


### PR DESCRIPTION
### Motivation
- Add TCP endpoint support alongside existing UDP to enable client/server and inout TCP communication patterns.
- Factor out common address/option parsing and errno mapping into socket utilities to share logic between UDP and TCP.
- Provide automated unit tests to validate basic TCP flows (server/client and out->in) and register them with CTest.
- Update documentation to describe TCP configuration fields and provide examples.

### Description
- Implemented `TcpEndpoint` with `include/hakoniwa/pdu/tcp_endpoint.hpp` and `src/tcp_endpoint.cpp` to handle client/server roles, connection timeouts, accept/connect semantics, and send/recv behavior.
- Added shared socket helpers in `include/hakoniwa/pdu/socket_utils.hpp` and `src/socket_utils.cpp` and refactored `src/udp_endpoint.cpp` to use these utilities (`kUdpSocketType`).
- Added JSON schema and samples for TCP at `config/schema/tcp_endpoint_schema.json` and `config/sample/tcp_endpoint.json`, and updated `README.md` to document UDP/TCP schemas and TCP config examples.
- Updated build and test integration by adding `socket_utils.cpp` and `tcp_endpoint.cpp` to `src/CMakeLists.txt` and registering `tcp_endpoint_test` in `test/CMakeLists.txt`, and added `test/tcp_endpoint_test.cpp` with two GTest cases.

### Testing
- No automated tests were executed in this rollout (no CI or `ctest` run was performed).
- The change adds unit tests `tcp_endpoint_test` and registers them with CTest via `add_test`, but they were not run here.
- This rollout did not include test execution results, so test pass/fail status is unknown.
- The README update is documentation-only and did not require runtime verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a4217d19083228d0ea3d6cbb33778)