### PR TITLE
Add SHM/WebSocket documentation and JSON schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@
 -   **Multiple Communication Protocols**:
     -   **TCP**: Client and Server roles for reliable, stream-based communication.
     -   **UDP**: Unicast, Broadcast, and Multicast for connectionless communication.
-    -   **Shared Memory**: Event-driven communication for high-performance, local IPC with Hakoniwa assets.
+    -   **Shared Memory (SHM)**: Event-driven communication for high-performance, local IPC with Hakoniwa assets.
+    -   **WebSocket**: Client and Server roles for stream-based communication over WebSocket.
 -   **Cross-platform**: Built with standard C++20 and CMake, making it portable across different operating systems.
 
 ## Requirements
@@ -61,6 +62,7 @@ The schemas for these can be found in `config/schema/`:
 - `endpoint_schema.json`
 - `cache_schema.json`
 - `comm_schema.json`
+- `pdu_def_schema.json`
 
 ### 1. Endpoint Configuration
 
@@ -100,11 +102,12 @@ These files define the in-memory storage strategy (e.g., `latest` mode or `queue
 
 ### 3. Communication (Comm) Configuration
 
-These files define the network protocol and parameters. See `config/sample/comm/` for examples for TCP, UDP, and SHM.
+These files define the network protocol and parameters. See `config/sample/comm/` for examples for TCP, UDP, SHM, and WebSocket.
 
 ### 4. PDU Definition File (Optional)
 
 This file maps human-readable PDU names to their channel IDs, sizes, and types. Providing this file in the endpoint configuration enables the high-level, name-based API.
+When using SHM communication, a PDU definition file is required so the shared-memory channel IDs can be resolved.
 
 **`pdudef.json` (Excerpt):**
 ```json
@@ -241,6 +244,7 @@ classDiagram
     class PduCommShm
     class TcpComm
     class UdpComm
+    class WebSocketComm
 
     Endpoint "1" o-- "0..1" PduDefinition : owns
     Endpoint "1" o-- "1" PduCache : owns
@@ -250,8 +254,9 @@ classDiagram
     PduComm <|-- PduCommShm
     PduComm <|-- TcpComm
     PduComm <|-- UdpComm
+    PduComm <|-- WebSocketComm
     
-    note for PduComm "Concrete implementations (TcpComm, UdpComm, PduCommShm)"
+    note for PduComm "Concrete implementations (TcpComm, UdpComm, WebSocketComm, PduCommShm)"
 
 ```
 
@@ -261,7 +266,7 @@ classDiagram
     -   **`Endpoint`**: The user-facing orchestrator. It composes the other modules and provides two API levels (name-based and ID-based).
     -   **`PduDefinition`**: (Optional) Manages the mapping between PDU string names and their technical details (channel ID, size), loaded from a JSON file.
     -   **`PduCache`**: An interface for in-memory data storage. Concrete implementations provide different caching strategies.
-    -   **`PduComm`**: An interface for communication modules. Concrete implementations (`TcpComm`, `UdpComm`, `PduCommShm`) handle the specifics of each protocol.
+    -   **`PduComm`**: An interface for communication modules. Concrete implementations (`TcpComm`, `UdpComm`, `WebSocketComm`, `PduCommShm`) handle the specifics of each protocol.
 
 2.  **Extensibility**: The design makes it easy to add new functionality without modifying existing core logic.
     -   **Adding a new protocol**: You would simply create a new class that inherits from `PduComm` (e.g., `WebSocketComm`) and implement its methods. The `Endpoint` class would not need any changes.

--- a/config/schema/comm_schema.json
+++ b/config/schema/comm_schema.json
@@ -1,13 +1,13 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Communication Endpoint Configuration",
-  "description": "Schema for communication endpoints (TCP or UDP).",
+  "description": "Schema for communication endpoints (TCP, UDP, SHM, WebSocket).",
   "type": "object",
-  "required": ["protocol", "name", "direction"],
+  "required": ["protocol", "direction"],
   "properties": {
     "protocol": {
       "type": "string",
-      "enum": ["tcp", "udp"],
+      "enum": ["tcp", "udp", "shm", "websocket"],
       "description": "Protocol type."
     },
     "name": {
@@ -24,18 +24,32 @@
     "role": {
       "type": "string",
       "enum": ["client", "server"],
-      "description": "TCP role (client: connects, server: listens)."
+      "description": "Client or server role (TCP/WebSocket)."
     },
-    "local": { "$ref": "#/$defs/endpoint" },
-    "remote": { "$ref": "#/$defs/endpoint" },
+    "local": {
+      "type": "object",
+      "description": "Local endpoint settings."
+    },
+    "remote": {
+      "type": "object",
+      "description": "Remote endpoint settings."
+    },
+    "pdu_config_path": {
+      "type": "string",
+      "description": "Optional PDU definition path for SHM configurations.",
+      "minLength": 1
+    },
+    "io": {
+      "$ref": "#/$defs/shm_io"
+    },
     "options": {
       "type": "object",
       "description": "Socket and protocol options.",
       "properties": {
         "backlog": { "type": "integer", "description": "TCP server listen backlog." },
-        "connect_timeout_ms": { "type": "integer", "description": "TCP connect timeout (ms)." },
-        "read_timeout_ms": { "type": "integer", "description": "TCP read timeout (ms)." },
-        "write_timeout_ms": { "type": "integer", "description": "TCP write timeout (ms)." },
+        "connect_timeout_ms": { "type": "integer", "description": "TCP/WebSocket connect timeout (ms)." },
+        "read_timeout_ms": { "type": "integer", "description": "TCP/WebSocket read timeout (ms)." },
+        "write_timeout_ms": { "type": "integer", "description": "TCP/WebSocket write timeout (ms)." },
         "blocking": { "type": "boolean", "description": "Blocking mode." },
         "reuse_address": { "type": "boolean", "description": "SO_REUSEADDR option." },
         "keepalive": { "type": "boolean", "description": "TCP keepalive." },
@@ -64,7 +78,9 @@
           "required": ["enabled"],
           "if": { "properties": { "enabled": { "const": true } } },
           "then": { "required": ["group"] }
-        }
+        },
+        "ping_interval_sec": { "type": "integer", "description": "WebSocket ping interval (seconds)." },
+        "handshake_timeout_ms": { "type": "integer", "description": "WebSocket handshake timeout (ms)." }
       }
     }
   },
@@ -72,6 +88,11 @@
     {
       "if": { "properties": { "protocol": { "const": "tcp" } } },
       "then": {
+        "required": ["name", "role"],
+        "properties": {
+          "local": { "$ref": "#/$defs/endpoint" },
+          "remote": { "$ref": "#/$defs/endpoint" }
+        },
         "anyOf": [
           {
             "if": { "properties": { "direction": { "const": "in" } } },
@@ -97,11 +118,55 @@
     {
       "if": { "properties": { "protocol": { "const": "udp" } } },
       "then": {
+        "required": ["name"],
+        "properties": {
+          "local": { "$ref": "#/$defs/endpoint" },
+          "remote": { "$ref": "#/$defs/endpoint" }
+        },
         "anyOf": [
           { "if": { "properties": { "direction": { "const": "in" } } }, "then": { "required": ["local"] } },
           { "if": { "properties": { "direction": { "const": "out" } } }, "then": { "required": ["remote"] } },
           { "if": { "properties": { "direction": { "const": "inout" } } }, "then": { "required": ["local"] } }
         ]
+      }
+    },
+    {
+      "if": { "properties": { "protocol": { "const": "websocket" } } },
+      "then": {
+        "required": ["role"],
+        "properties": {
+          "local": { "$ref": "#/$defs/ws_local" },
+          "remote": { "$ref": "#/$defs/ws_remote" }
+        },
+        "anyOf": [
+          {
+            "if": { "properties": { "direction": { "const": "in" } } },
+            "then": { "required": ["local"], "properties": { "role": { "const": "server" } } }
+          },
+          {
+            "if": { "properties": { "direction": { "const": "out" } } },
+            "then": { "required": ["remote"], "properties": { "role": { "const": "client" } } }
+          },
+          {
+            "if": { "properties": { "direction": { "const": "inout" } } },
+            "then": {
+              "required": ["role"],
+              "anyOf": [
+                { "if": { "properties": { "role": { "const": "server" } } }, "then": { "required": ["local"] } },
+                { "if": { "properties": { "role": { "const": "client" } } }, "then": { "required": ["remote"] } }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "if": { "properties": { "protocol": { "const": "shm" } } },
+      "then": {
+        "required": ["name", "io"],
+        "properties": {
+          "io": { "$ref": "#/$defs/shm_io" }
+        }
       }
     }
   ],
@@ -123,6 +188,84 @@
           "description": "Port number.",
           "minimum": 1,
           "maximum": 65535
+        }
+      }
+    },
+    "ws_local": {
+      "type": "object",
+      "required": ["port"],
+      "properties": {
+        "port": {
+          "type": "integer",
+          "description": "Listen port number.",
+          "minimum": 1,
+          "maximum": 65535
+        }
+      }
+    },
+    "ws_remote": {
+      "type": "object",
+      "required": ["host", "port"],
+      "properties": {
+        "host": {
+          "type": "string",
+          "description": "Remote host name or IP address.",
+          "minLength": 1
+        },
+        "port": {
+          "type": "integer",
+          "description": "Remote port number.",
+          "minimum": 1,
+          "maximum": 65535
+        },
+        "path": {
+          "type": "string",
+          "description": "WebSocket path.",
+          "minLength": 1,
+          "default": "/"
+        },
+        "secure": {
+          "type": "boolean",
+          "description": "Enable secure WebSocket (wss)."
+        }
+      }
+    },
+    "shm_io": {
+      "type": "object",
+      "required": ["robots"],
+      "properties": {
+        "robots": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/shm_robot" }
+        }
+      }
+    },
+    "shm_robot": {
+      "type": "object",
+      "required": ["name", "pdu"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "pdu": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/shm_pdu" }
+        }
+      }
+    },
+    "shm_pdu": {
+      "type": "object",
+      "required": ["name", "notify_on_recv"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "notify_on_recv": {
+          "type": "boolean"
         }
       }
     }

--- a/config/schema/endpoint_schema.json
+++ b/config/schema/endpoint_schema.json
@@ -3,7 +3,7 @@
   "title": "Endpoint Configuration",
   "description": "Schema for a single endpoint entry, linking a name to cache and communication configurations.",
   "type": "object",
-  "required": ["name", "cache", "comm"],
+  "required": ["name", "cache"],
   "properties": {
     "name": {
       "type": "string",
@@ -20,6 +20,11 @@
       "type": ["string", "null"],
       "description": "Path to the communication configuration file, or null if no communication is used (e.g., for internal endpoints).",
       "pattern": "^(comm\/)?.*\.json$"
+    },
+    "pdu_def_path": {
+      "type": ["string", "null"],
+      "description": "Optional path to a PDU definition file for name-based resolution.",
+      "pattern": ".*\\.json$"
     }
   }
 }

--- a/config/schema/pdu_def_schema.json
+++ b/config/schema/pdu_def_schema.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "PDU Definition Configuration",
+  "description": "Schema for PDU definition files used to resolve names to channel IDs and sizes.",
+  "type": "object",
+  "required": ["robots"],
+  "properties": {
+    "robots": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/robot" }
+    }
+  },
+  "$defs": {
+    "robot": {
+      "type": "object",
+      "required": ["name"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "shm_pdu_readers": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/pdu_entry" }
+        },
+        "shm_pdu_writers": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/pdu_entry" }
+        },
+        "rpc_pdu_readers": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/pdu_entry" }
+        },
+        "rpc_pdu_writers": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/pdu_entry" }
+        }
+      }
+    },
+    "pdu_entry": {
+      "type": "object",
+      "required": ["type", "org_name", "channel_id", "pdu_size"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "org_name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "channel_id": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "pdu_size": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "write_cycle": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "method_type": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Motivation
- Document newly supported communication protocols so users can configure SHM and WebSocket endpoints. 
- Provide machine-readable validation for PDU definition files so name-based resolution for SHM is well defined. 
- Align endpoint schema with optional `comm` and optional `pdu_def_path` to reflect runtime flexibility. 

### Description
- Updated `README.md` to mention `Shared Memory (SHM)` and `WebSocket` support and to reference the new `pdu_def_schema.json`. 
- Extended `config/schema/comm_schema.json` to include `shm` and `websocket` protocols, WebSocket `local/remote` shapes, and SHM `io`/`pdu` structure. 
- Modified `config/schema/endpoint_schema.json` to make `comm` optional and add an optional `pdu_def_path` property. 
- Added new schema file `config/schema/pdu_def_schema.json` to validate PDU definition files (`pdudef.json`). 

### Testing
- No automated tests were run as part of this change because it modifies documentation and JSON schemas only. 
- Schema files were inspected manually for consistency with existing sample configs and code references. 
- Project build and runtime code were not modified by these schema changes, so compilation was not required. 
- No test failures occurred (no tests executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694dfcf356448322b4592d4521c401d2)