### PR TITLE
Improve comm thread-safety: atomic FD access, SHM map locking, and Endpoint threading docs

### DIFF
--- a/include/hakoniwa/pdu/comm/comm_raw.hpp
+++ b/include/hakoniwa/pdu/comm/comm_raw.hpp
@@ -5,14 +5,14 @@
 #include <vector>
 #include <string>
 #include <mutex> // Add mutex include
- #include <memory>
- // Removed <deque>, <mutex>, <condition_variable>
- 
- namespace hakoniwa {
- namespace pdu {
- namespace comm {
- 
- class PduCommRaw : public PduComm {
+#include <memory>
+// Removed <deque>, <mutex>, <condition_variable>
+
+namespace hakoniwa {
+namespace pdu {
+namespace comm {
+
+class PduCommRaw : public PduComm {
  public:
      PduCommRaw() = default;
      virtual ~PduCommRaw() = default;

--- a/include/hakoniwa/pdu/endpoint.hpp
+++ b/include/hakoniwa/pdu/endpoint.hpp
@@ -25,6 +25,13 @@ namespace hakoniwa {
 namespace pdu {
 using OnRecvCallback = std::function<void(const PduResolvedKey&, std::span<const std::byte>)>;
 
+/*
+ * Threading assumptions:
+ * - open/close/start/stop are called from a single thread (initialization/shutdown).
+ * - set_on_recv_callback is configured during initialization and not changed afterward.
+ * - send/recv may be called from multiple threads, but callers must serialize access if needed.
+ * - Comm implementations may use background threads; close/stop can be used to interrupt blocking I/O.
+ */
 class Endpoint
 {
 public:

--- a/src/comm_shm.cpp
+++ b/src/comm_shm.cpp
@@ -140,12 +140,15 @@ void PduCommShm::handle_shm_recv(int recv_event_id) {
         return;
     }
 
-    auto it = event_id_to_key_map_.find(recv_event_id);
-    if (it == event_id_to_key_map_.end()) {
-        return; // Not found
+    PduResolvedKey key{};
+    {
+        std::lock_guard<std::mutex> lock(event_map_mutex_);
+        auto it = event_id_to_key_map_.find(recv_event_id);
+        if (it == event_id_to_key_map_.end()) {
+            return; // Not found
+        }
+        key = it->second;
     }
-
-    const PduResolvedKey& key = it->second;
     PduDef def;
     if (!pdu_def_->resolve(key.robot, key.channel_id, def)) { // Access inherited member
         std::cerr << "PduCommShm Error: Can't resolve PDU for received event. Robot: " << key.robot << " Channel: " << key.channel_id << std::endl;


### PR DESCRIPTION
### Motivation

- Prevent data races when comm sockets are accessed from background threads by consistently reading atomic file-descriptor members via `load()` and using local copies for syscalls. 
- Clarify threading expectations for `Endpoint` users and implementers so initialization and callback usage are explicit. 
- Avoid races on SHM event handling by serializing access to the `event_id_to_key_map_` during lookups. 
- Ensure raw send/encoding operations are serialized to prevent concurrent encoding/queue races.

### Description

- Updated TCP and UDP implementations to call `*.load()` on atomic fd members (`client_fd_`, `listen_fd_`, `socket_fd_`) and use local integer variables for `close`, `shutdown`, `sendto`, `recvfrom`, `accept`, and other socket calls. 
- Added a scoped `std::lock_guard<std::mutex>` around `event_id_to_key_map_` lookups in `PduCommShm::handle_shm_recv` to copy the resolved `PduResolvedKey` under lock. 
- Documented threading assumptions in `include/hakoniwa/pdu/endpoint.hpp` describing which methods are expected to be single-threaded and how callbacks/send/recv should be used. 
- Introduced `send_mutex_` and a lock in `PduCommRaw::send` to serialize packet encoding and call into `raw_send`, and cleaned up related formatting/headers in `include/hakoniwa/pdu/comm/comm_raw.hpp`.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960263e1f9083229e838cb1466fe0d1)