### PR TITLE
Add file-based Storage comm backend (queue/latest) with validation and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ This design is intentionally biased toward large, multi-asset simulations: it fa
     -   **UDP**: Unicast, Broadcast, and Multicast for connectionless communication.
     -   **Shared Memory (SHM)**: Event-driven communication for high-performance, local IPC with Hakoniwa assets.
     -   **WebSocket**: Client and Server roles for stream-based communication over WebSocket.
+    -   **Storage (File)**: Persistent communication backend for audit/replay use cases.
+        - `mode: queue` stores every send as an append-only framed record.
+        - `mode: latest` stores only the latest packet per `(robot, channel_id)`.
 -   **Cross-platform**: Built with standard C++20 and CMake, making it portable across different operating systems.
 
 ## Requirements
@@ -194,7 +197,29 @@ These files define the in-memory storage strategy (e.g., `latest` mode or `queue
 
 ### 3. Communication (Comm) Configuration
 
-These files define the network protocol and parameters. See `config/sample/comm/` for examples for TCP, UDP, SHM, and WebSocket.
+These files define the network protocol and parameters. See `config/sample/comm/` for examples for TCP, UDP, SHM, WebSocket, and Storage.
+
+#### Storage comm (file backend)
+
+Storage comm can be used for persistence-oriented pipelines.
+
+- `protocol: "storage"`
+- `storage.backend: "file"`
+- `storage.mode: "queue" | "latest"`
+- `storage.path`: output/input file path (resolved relative to comm config)
+
+`queue` mode stores records as a repeated binary frame:
+
+```text
+<u32_le packet_size><packet_bytes>
+```
+
+`latest` mode keeps one latest packet per `(robot, channel_id)` key.
+
+Sample configs:
+
+- `config/sample/comm/storage_queue_out_comm.json`
+- `config/sample/comm/storage_latest_out_comm.json`
 
 #### Optional: host name resolver for TCP/UDP
 

--- a/docs/issue_storage_status.md
+++ b/docs/issue_storage_status.md
@@ -1,0 +1,69 @@
+# Storage Comm status and next steps (issue.md alignment)
+
+## Current implementation status
+
+As of now, `StorageComm` already supports both persistence modes described in `issue.md`.
+
+- `queue` mode: appends every framed packet in send order to a file backend.
+- `latest` mode: keeps one latest packet per `(robot, channel_id)` key and updates index metadata.
+
+The implementation is wired through:
+
+- `protocol: "storage"` in comm config schema.
+- file backend configuration (`storage.path`).
+- mode selection (`storage.mode = latest | queue`).
+
+## Confirmed behavior in tests
+
+The endpoint tests currently verify the main storage behaviors:
+
+- queue mode persists all sends.
+- latest mode keeps only the latest packet per channel key.
+- latest mode can be read back by an IN endpoint when file/index are valid.
+- latest mode rejects uninitialized index entries on open.
+
+## Gap against issue.md
+
+The remaining gap is mostly around the **metadata design depth** and replay-read semantics for `queue` mode.
+
+`issue.md` asks for a more explicit three-layer storage format and richer metadata fields. The current code already has practical headers and indexing, but does not yet expose all suggested metadata fields (for example broad file-level timestamps/ranges) nor a replay-oriented API for queue-mode reads.
+
+## Queue data specification (current implementation)
+
+Current `queue` mode uses a simple append-only binary stream without a file header.
+
+Each record is encoded as:
+
+1. `packet_size` (4 bytes, little-endian `uint32`)
+2. `packet_bytes` (`packet_size` bytes)
+
+In pseudo format:
+
+```text
+record := <u32_le packet_size> <byte[packet_size] packet>
+file   := record*
+```
+
+Notes:
+
+- The file has no global metadata area yet (version/mode/index/range are not embedded for queue mode in the current implementation).
+- `packet_bytes` is the encoded raw comm packet (`DataPacket::encode(comm_raw_version)`), so `robot`, `channel_id`, and payload are preserved inside the packet body.
+- Writers append records in send order by opening the file with `std::ios::app`; therefore queue mode currently guarantees append order but does not yet provide a `queue`-mode `recv()` cursor API.
+- Existing test helpers read queue records using the same `<u32_le size> + packet` framing and validate that all sends are persisted in order.
+
+## Suggested implementation order
+
+1. Extend queue-file header/metadata with explicit counts and optional time range fields.
+2. Add `queue` read path (`recv`) with sequential cursor semantics.
+3. Add optional filtering hooks (`robot`, `channel_id`) for offline/replay readers.
+4. Keep backward compatibility by versioning format and accepting existing v1 files.
+
+## Notes on compact PDU baseline
+
+The compact PDU schema remains the right baseline for new work:
+
+- `new-pdudef.json` maps robot to `pdutypes_id`.
+- `paths[]` links to `new-pdutypes.json`.
+- actual typed entries include `channel_id`, `pdu_size`, `name`, and `type`.
+
+Storage metadata should continue recording actual payload length per record, even when `pdu_size` exists in compact definitions.

--- a/include/hakoniwa/pdu/comm/comm_storage.hpp
+++ b/include/hakoniwa/pdu/comm/comm_storage.hpp
@@ -73,6 +73,7 @@ private:
 
     HakoPduErrorType parse_config_(const std::string& config_path);
     HakoPduErrorType initialize_latest_file_();
+    HakoPduErrorType validate_queue_file_();
     HakoPduErrorType load_latest_file_();
     HakoPduErrorType write_latest_header_(std::fstream& fs) noexcept;
     HakoPduErrorType write_latest_index_entry_(std::fstream& fs, const LatestKey& key) noexcept;
@@ -87,6 +88,7 @@ private:
     std::mutex io_mutex_;
     std::map<LatestKey, std::vector<std::byte>> latest_packets_;
     std::map<LatestKey, LatestIndexEntry> latest_index_;
+    std::map<LatestKey, std::uint64_t> queue_offsets_;
 };
 
 } // namespace comm

--- a/src/comm_storage.cpp
+++ b/src/comm_storage.cpp
@@ -78,6 +78,7 @@ HakoPduErrorType StorageComm::raw_open(const std::string& config_path)
 
     latest_packets_.clear();
     latest_index_.clear();
+    queue_offsets_.clear();
     if (mode_ == Mode::Latest) {
         if (direction_ == HAKO_PDU_ENDPOINT_DIRECTION_IN && !fs::exists(path_)) {
             return HAKO_PDU_ERR_FILE_NOT_FOUND;
@@ -85,6 +86,16 @@ HakoPduErrorType StorageComm::raw_open(const std::string& config_path)
         err = initialize_latest_file_();
         if (err != HAKO_PDU_ERR_OK) {
             return err;
+        }
+    } else {
+        if (direction_ == HAKO_PDU_ENDPOINT_DIRECTION_IN && !fs::exists(path_)) {
+            return HAKO_PDU_ERR_FILE_NOT_FOUND;
+        }
+        if (fs::exists(path_)) {
+            err = validate_queue_file_();
+            if (err != HAKO_PDU_ERR_OK) {
+                return err;
+            }
         }
     }
 
@@ -99,6 +110,7 @@ HakoPduErrorType StorageComm::raw_close() noexcept
     is_open_ = false;
     latest_packets_.clear();
     latest_index_.clear();
+    queue_offsets_.clear();
     return HAKO_PDU_ERR_OK;
 }
 
@@ -135,14 +147,63 @@ HakoPduErrorType StorageComm::recv(const PduResolvedKey& pdu_key,
     if (!is_running_) {
         return HAKO_PDU_ERR_NOT_RUNNING;
     }
-    if (mode_ != Mode::Latest) {
-        return HAKO_PDU_ERR_UNSUPPORTED;
-    }
     if (direction_ == HAKO_PDU_ENDPOINT_DIRECTION_OUT) {
         return HAKO_PDU_ERR_INVALID_ARGUMENT;
     }
 
     const auto key = LatestKey{pdu_key.robot, pdu_key.channel_id};
+    if (mode_ == Mode::Queue) {
+        std::ifstream ifs(path_, std::ios::binary);
+        if (!ifs.is_open()) {
+            return HAKO_PDU_ERR_IO_ERROR;
+        }
+        auto& read_offset = queue_offsets_[key];
+        ifs.seekg(static_cast<std::streamoff>(read_offset), std::ios::beg);
+        if (!ifs.good()) {
+            return HAKO_PDU_ERR_IO_ERROR;
+        }
+
+        while (true) {
+            const auto frame_start = ifs.tellg();
+            std::uint32_t packet_size = 0;
+            if (!read_le32_(ifs, packet_size)) {
+                if (ifs.eof()) {
+                    ifs.clear();
+                    ifs.seekg(0, std::ios::end);
+                    read_offset = static_cast<std::uint64_t>(ifs.tellg());
+                    return HAKO_PDU_ERR_NO_ENTRY;
+                }
+                return HAKO_PDU_ERR_IO_ERROR;
+            }
+
+            std::vector<std::byte> packet(packet_size);
+            if (!ifs.read(reinterpret_cast<char*>(packet.data()), static_cast<std::streamsize>(packet.size()))) {
+                return HAKO_PDU_ERR_INVALID_CONFIG;
+            }
+
+            auto decoded = DataPacket::decode(packet, packet_version());
+            if (!decoded) {
+                return HAKO_PDU_ERR_INVALID_CONFIG;
+            }
+
+            const auto frame_end = ifs.tellg();
+            if (decoded->get_robot_name() == pdu_key.robot
+                && decoded->get_channel_id() == static_cast<std::uint32_t>(pdu_key.channel_id)) {
+                const auto& payload = decoded->get_pdu_data();
+                received_size = payload.size();
+                if (data.size() < payload.size()) {
+                    return HAKO_PDU_ERR_NO_SPACE;
+                }
+                std::copy(payload.begin(), payload.end(), data.begin());
+                read_offset = static_cast<std::uint64_t>(frame_end);
+                return HAKO_PDU_ERR_OK;
+            }
+            if (frame_end <= frame_start) {
+                return HAKO_PDU_ERR_INVALID_CONFIG;
+            }
+        }
+    }
+
     auto it_index = latest_index_.find(key);
     if (it_index == latest_index_.end()) {
         return HAKO_PDU_ERR_INVALID_PDU_KEY;
@@ -280,6 +341,37 @@ HakoPduErrorType StorageComm::parse_config_(const std::string& config_path)
     }
     path_ = resolve_under_base_(fs::path(config_path).parent_path(), storage.at("path").get<std::string>());
     return HAKO_PDU_ERR_OK;
+}
+
+HakoPduErrorType StorageComm::validate_queue_file_()
+{
+    std::ifstream ifs(path_, std::ios::binary);
+    if (!ifs.is_open()) {
+        return HAKO_PDU_ERR_IO_ERROR;
+    }
+
+    while (true) {
+        const auto frame_start = ifs.tellg();
+        std::uint32_t packet_size = 0;
+        if (!read_le32_(ifs, packet_size)) {
+            if (ifs.eof()) {
+                return HAKO_PDU_ERR_OK;
+            }
+            return HAKO_PDU_ERR_IO_ERROR;
+        }
+
+        std::vector<std::byte> packet(packet_size);
+        if (!ifs.read(reinterpret_cast<char*>(packet.data()), static_cast<std::streamsize>(packet.size()))) {
+            return HAKO_PDU_ERR_INVALID_CONFIG;
+        }
+        if (!DataPacket::decode(packet, packet_version())) {
+            return HAKO_PDU_ERR_INVALID_CONFIG;
+        }
+
+        if (ifs.tellg() <= frame_start) {
+            return HAKO_PDU_ERR_INVALID_CONFIG;
+        }
+    }
 }
 
 HakoPduErrorType StorageComm::initialize_latest_file_()

--- a/test/endpoint_test.cpp
+++ b/test/endpoint_test.cpp
@@ -853,6 +853,201 @@ TEST_F(EndpointTest, StorageCommQueueModePersistsAllSends) {
     EXPECT_EQ(decoded1->get_pdu_data(), (std::vector<std::byte>{std::byte{0xBB}, std::byte{0xCC}}));
 }
 
+TEST_F(EndpointTest, StorageCommQueueOpenValidatesExistingFile) {
+    namespace fs = std::filesystem;
+    const auto temp_base = fs::temp_directory_path() / "hako_pdu_storage_queue_open_validate_test";
+    const auto cache_path = (fs::current_path() / "config/sample/cache/buffer.json").string();
+    fs::remove_all(temp_base);
+    fs::create_directories(temp_base);
+
+    const auto comm_path = temp_base / "storage_queue_in_comm.json";
+    const auto endpoint_path = temp_base / "endpoint.json";
+    const auto storage_path = temp_base / "storage_queue.bin";
+
+    {
+        hakoniwa::pdu::comm::DataPacket packet("robot_storage", 10U, std::vector<std::byte>{std::byte{0x11}});
+        const auto encoded = packet.encode("v2");
+        std::ofstream ofs(storage_path, std::ios::binary | std::ios::trunc);
+        ASSERT_TRUE(ofs.is_open());
+        const std::uint32_t size = static_cast<std::uint32_t>(encoded.size());
+        const char len_buf[4] = {
+            static_cast<char>(size & 0xFFu),
+            static_cast<char>((size >> 8) & 0xFFu),
+            static_cast<char>((size >> 16) & 0xFFu),
+            static_cast<char>((size >> 24) & 0xFFu)
+        };
+        ofs.write(len_buf, sizeof(len_buf));
+        ofs.write(reinterpret_cast<const char*>(encoded.data()), static_cast<std::streamsize>(encoded.size()));
+    }
+    {
+        std::ofstream ofs(comm_path);
+        ASSERT_TRUE(ofs.is_open());
+        ofs << nlohmann::json{
+            {"protocol", "storage"},
+            {"direction", "in"},
+            {"comm_raw_version", "v2"},
+            {"storage", {
+                {"backend", "file"},
+                {"mode", "queue"},
+                {"path", storage_path.string()}
+            }}
+        }.dump(2);
+    }
+    {
+        std::ofstream ofs(endpoint_path);
+        ASSERT_TRUE(ofs.is_open());
+        ofs << nlohmann::json{
+            {"name", "storage_queue_in_endpoint"},
+            {"cache", cache_path},
+            {"comm", comm_path.string()}
+        }.dump(2);
+    }
+
+    hakoniwa::pdu::Endpoint endpoint("storage_queue_in_test", HAKO_PDU_ENDPOINT_DIRECTION_IN);
+    ASSERT_EQ(endpoint.open(endpoint_path.string()), HAKO_PDU_ERR_OK);
+    ASSERT_EQ(endpoint.close(), HAKO_PDU_ERR_OK);
+}
+
+TEST_F(EndpointTest, StorageCommQueueInOpenFailsWhenFrameIsTruncated) {
+    namespace fs = std::filesystem;
+    const auto temp_base = fs::temp_directory_path() / "hako_pdu_storage_queue_open_fail_test";
+    const auto cache_path = (fs::current_path() / "config/sample/cache/buffer.json").string();
+    fs::remove_all(temp_base);
+    fs::create_directories(temp_base);
+
+    const auto comm_path = temp_base / "storage_queue_in_comm.json";
+    const auto endpoint_path = temp_base / "endpoint.json";
+    const auto storage_path = temp_base / "storage_queue_corrupted.bin";
+
+    {
+        std::ofstream ofs(storage_path, std::ios::binary | std::ios::trunc);
+        ASSERT_TRUE(ofs.is_open());
+        const char len_buf[4] = {0x08, 0x00, 0x00, 0x00};
+        const char payload[3] = {0x01, 0x02, 0x03};
+        ofs.write(len_buf, sizeof(len_buf));
+        ofs.write(payload, sizeof(payload));
+    }
+    {
+        std::ofstream ofs(comm_path);
+        ASSERT_TRUE(ofs.is_open());
+        ofs << nlohmann::json{
+            {"protocol", "storage"},
+            {"direction", "in"},
+            {"comm_raw_version", "v2"},
+            {"storage", {
+                {"backend", "file"},
+                {"mode", "queue"},
+                {"path", storage_path.string()}
+            }}
+        }.dump(2);
+    }
+    {
+        std::ofstream ofs(endpoint_path);
+        ASSERT_TRUE(ofs.is_open());
+        ofs << nlohmann::json{
+            {"name", "storage_queue_in_endpoint"},
+            {"cache", cache_path},
+            {"comm", comm_path.string()}
+        }.dump(2);
+    }
+
+    hakoniwa::pdu::Endpoint endpoint("storage_queue_in_fail_test", HAKO_PDU_ENDPOINT_DIRECTION_IN);
+    ASSERT_EQ(endpoint.open(endpoint_path.string()), HAKO_PDU_ERR_INVALID_CONFIG);
+}
+
+TEST_F(EndpointTest, StorageCommQueueInRecvFiltersByKeyInOrder) {
+    namespace fs = std::filesystem;
+    const auto temp_base = fs::temp_directory_path() / "hako_pdu_storage_queue_recv_filter_test";
+    const auto cache_path = (fs::current_path() / "config/sample/cache/buffer.json").string();
+    fs::remove_all(temp_base);
+    fs::create_directories(temp_base);
+
+    const auto storage_path = temp_base / "storage_queue.bin";
+    const auto out_comm_path = temp_base / "storage_queue_out_comm.json";
+    const auto in_comm_path = temp_base / "storage_queue_in_comm.json";
+    const auto out_endpoint_path = temp_base / "endpoint_out.json";
+    const auto in_endpoint_path = temp_base / "endpoint_in.json";
+
+    {
+        std::ofstream ofs(out_comm_path);
+        ASSERT_TRUE(ofs.is_open());
+        ofs << nlohmann::json{
+            {"protocol", "storage"},
+            {"direction", "out"},
+            {"comm_raw_version", "v2"},
+            {"storage", {
+                {"backend", "file"},
+                {"mode", "queue"},
+                {"path", storage_path.string()}
+            }}
+        }.dump(2);
+    }
+    {
+        std::ofstream ofs(in_comm_path);
+        ASSERT_TRUE(ofs.is_open());
+        ofs << nlohmann::json{
+            {"protocol", "storage"},
+            {"direction", "in"},
+            {"comm_raw_version", "v2"},
+            {"storage", {
+                {"backend", "file"},
+                {"mode", "queue"},
+                {"path", storage_path.string()}
+            }}
+        }.dump(2);
+    }
+    {
+        std::ofstream ofs(out_endpoint_path);
+        ASSERT_TRUE(ofs.is_open());
+        ofs << nlohmann::json{
+            {"name", "storage_queue_out_endpoint"},
+            {"cache", cache_path},
+            {"comm", out_comm_path.string()}
+        }.dump(2);
+    }
+    {
+        std::ofstream ofs(in_endpoint_path);
+        ASSERT_TRUE(ofs.is_open());
+        ofs << nlohmann::json{
+            {"name", "storage_queue_in_endpoint"},
+            {"cache", cache_path},
+            {"comm", in_comm_path.string()}
+        }.dump(2);
+    }
+
+    hakoniwa::pdu::Endpoint writer("storage_queue_writer", HAKO_PDU_ENDPOINT_DIRECTION_OUT);
+    ASSERT_EQ(writer.open(out_endpoint_path.string()), HAKO_PDU_ERR_OK);
+    ASSERT_EQ(writer.start(), HAKO_PDU_ERR_OK);
+    ASSERT_EQ(writer.send(create_key("RobotA", 10), std::vector<std::byte>{std::byte{0x01}}), HAKO_PDU_ERR_OK);
+    ASSERT_EQ(writer.send(create_key("RobotB", 20), std::vector<std::byte>{std::byte{0x0A}}), HAKO_PDU_ERR_OK);
+    ASSERT_EQ(writer.send(create_key("RobotA", 10), std::vector<std::byte>{std::byte{0x02}}), HAKO_PDU_ERR_OK);
+    ASSERT_EQ(writer.stop(), HAKO_PDU_ERR_OK);
+    ASSERT_EQ(writer.close(), HAKO_PDU_ERR_OK);
+
+    hakoniwa::pdu::Endpoint reader("storage_queue_reader", HAKO_PDU_ENDPOINT_DIRECTION_IN);
+    ASSERT_EQ(reader.open(in_endpoint_path.string()), HAKO_PDU_ERR_OK);
+    ASSERT_EQ(reader.start(), HAKO_PDU_ERR_OK);
+
+    std::vector<std::byte> recv_buf(4);
+    size_t recv_size = 0;
+    ASSERT_EQ(reader.recv(create_key("RobotA", 10), recv_buf, recv_size), HAKO_PDU_ERR_OK);
+    ASSERT_EQ(recv_size, 1U);
+    EXPECT_EQ(recv_buf[0], std::byte{0x01});
+
+    ASSERT_EQ(reader.recv(create_key("RobotA", 10), recv_buf, recv_size), HAKO_PDU_ERR_OK);
+    ASSERT_EQ(recv_size, 1U);
+    EXPECT_EQ(recv_buf[0], std::byte{0x02});
+
+    ASSERT_EQ(reader.recv(create_key("RobotA", 10), recv_buf, recv_size), HAKO_PDU_ERR_NO_ENTRY);
+
+    ASSERT_EQ(reader.recv(create_key("RobotB", 20), recv_buf, recv_size), HAKO_PDU_ERR_OK);
+    ASSERT_EQ(recv_size, 1U);
+    EXPECT_EQ(recv_buf[0], std::byte{0x0A});
+
+    ASSERT_EQ(reader.stop(), HAKO_PDU_ERR_OK);
+    ASSERT_EQ(reader.close(), HAKO_PDU_ERR_OK);
+}
+
 TEST_F(EndpointTest, StorageCommLatestModeKeepsOnlyLatestPerChannel) {
     namespace fs = std::filesystem;
     const auto temp_base = fs::temp_directory_path() / "hako_pdu_storage_latest_test";


### PR DESCRIPTION
### Motivation

- Provide a persistent `storage` communication backend so endpoints can persist and replay PDUs for audit and offline workflows.

### Description

- Implement a file-backed `StorageComm` supporting `mode: queue` (append-only framed records) and `mode: latest` (one latest packet per `(robot, channel_id)`) with config parsing via `storage.backend`, `storage.mode`, and `storage.path` in `comm` configs.
- Add queue-mode read validation and per-key cursor state via `validate_queue_file_()`, `queue_offsets_`, and a queue-mode read path in `recv()` that scans framed records and returns matching entries in send order.
- Add README and docs updates describing the `storage` comm, sample config names, framing (`<u32_le packet_size><packet_bytes>`), and implementation status in `docs/issue_storage_status.md`.
- Add unit tests in `test/endpoint_test.cpp` covering queue persistence, open-time validation, truncated-file rejection, and ordered keyed reads; and adjust code headers in `include/hakoniwa/pdu/comm/comm_storage.hpp`.

### Testing

- Ran the `EndpointTest` suite including new storage tests `StorageCommQueueModePersistsAllSends`, `StorageCommQueueOpenValidatesExistingFile`, `StorageCommQueueInOpenFailsWhenFrameIsTruncated`, and `StorageCommQueueInRecvFiltersByKeyInOrder`, which all passed locally.
- Existing latest-mode tests (`StorageCommLatestModeKeepsOnlyLatestPerChannel`) were retained and exercised as part of the suite and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b60dd3216c832288d79037076c1adb)