### PR TITLE
Add UDP subscriber runner callback

### DIFF
--- a/benchmarks/runner/comm/sub_runner.hpp
+++ b/benchmarks/runner/comm/sub_runner.hpp
@@ -2,6 +2,8 @@
 
 #include "runner.hpp"
 
+#include <atomic>
+
 namespace benchmarks::runner {
 
 class SubShmRunner : public Runner {
@@ -23,6 +25,10 @@ public:
     void prepare(int num, std::string endpoint_config_path) override;
     void run() override;
     void cleanup() override;
+
+private:
+    std::atomic<int> expected_count_{0};
+    std::atomic<int> received_count_{0};
 };
 
 }

--- a/benchmarks/runner/comm/sub_runner_udp.cpp
+++ b/benchmarks/runner/comm/sub_runner_udp.cpp
@@ -1,17 +1,89 @@
 #include "sub_runner.hpp"
+#include "hakoniwa/pdu/endpoint.hpp"
+
+#include <chrono>
+#include <iostream>
+#include <stdexcept>
+#include <thread>
 
 namespace benchmarks::runner {
 
-void SubUdpRunner::prepare(int num, std::string endpoint_config_path) {
-    // TODO: Implementation
+void SubUdpRunner::prepare(int num, std::string endpoint_config_path)
+{
+    expected_count_.store(num);
+    received_count_.store(0);
+
+    endpoint_ = std::make_unique<hakoniwa::pdu::Endpoint>(
+        "sub_runner_udp",
+        HAKO_PDU_ENDPOINT_DIRECTION_IN);
+
+    if (endpoint_->open(endpoint_config_path) != HAKO_PDU_ERR_OK) {
+        endpoint_.reset();
+        throw std::runtime_error("Failed to open UDP subscriber endpoint");
+    }
+
+    for (int i = 0; i < num; ++i) {
+        hakoniwa::pdu::PduKey key = {"Drone-" + std::to_string(i + 1), "pos"};
+        const auto channel_id = endpoint_->get_pdu_channel_id(key);
+        if (channel_id < 0) {
+            endpoint_->close();
+            endpoint_.reset();
+            throw std::runtime_error(
+                "Failed to get PDU channel ID for key: " + key.robot + "/" + key.pdu);
+        }
+
+        hakoniwa::pdu::PduResolvedKey resolved_key = {key.robot, channel_id};
+        endpoint_->subscribe_on_recv_callback(
+            resolved_key,
+            [this](const hakoniwa::pdu::PduResolvedKey& received_key,
+                   std::span<const std::byte> data) {
+                const int count = received_count_.fetch_add(1) + 1;
+                std::cout
+                    << "Received UDP PDU: robot=" << received_key.robot
+                    << " channel=" << received_key.channel_id
+                    << " size=" << data.size()
+                    << " count=" << count
+                    << std::endl;
+            });
+    }
+
+    if (endpoint_->start() != HAKO_PDU_ERR_OK) {
+        endpoint_->close();
+        endpoint_.reset();
+        throw std::runtime_error("Failed to start UDP subscriber endpoint");
+    }
 }
 
-void SubUdpRunner::run() {
-    // TODO: Implementation
+void SubUdpRunner::run()
+{
+    if (!endpoint_) {
+        throw std::runtime_error("Endpoint not initialized");
+    }
+
+    constexpr int max_wait_ms = 3000;
+    constexpr int sleep_ms = 10;
+
+    for (int elapsed_ms = 0; elapsed_ms < max_wait_ms; elapsed_ms += sleep_ms) {
+        if (received_count_.load() >= expected_count_.load()) {
+            return;
+        }
+        endpoint_->process_recv_events();
+        std::this_thread::sleep_for(std::chrono::milliseconds(sleep_ms));
+    }
+
+    std::cerr
+        << "Timed out waiting for UDP PDUs: received=" << received_count_.load()
+        << " expected=" << expected_count_.load()
+        << std::endl;
 }
 
-void SubUdpRunner::cleanup() {
-    // TODO: Implementation
+void SubUdpRunner::cleanup()
+{
+    if (endpoint_) {
+        endpoint_->stop();
+        endpoint_->close();
+        endpoint_.reset();
+    }
 }
 
 }


### PR DESCRIPTION
## Summary

- Implement UDP subscriber runner initialization and cleanup
- Register per-PDU receive callbacks with `subscribe_on_recv_callback`
- Add a small wait loop that calls `process_recv_events()` and logs received UDP PDUs

## Notes

This is intentionally a smoke-test level implementation for the benchmark runner. It verifies that UDP receive callbacks can be registered and triggered before adding latency/throughput measurement logic.