### PR TITLE
Measure receive-event benchmark timing for UDP and TCP

### DIFF
--- a/benchmarks/runner/comm/pub_runner_tcp.cpp
+++ b/benchmarks/runner/comm/pub_runner_tcp.cpp
@@ -1,5 +1,6 @@
 #include "pub_runner.hpp"
 #include "hakoniwa/pdu/endpoint.hpp"
+
 #include <iostream>
 #include <stdexcept>
 
@@ -26,25 +27,41 @@ void PubTcpRunner::prepare()
     create_send_buffer_for_key(benchmark_config_.try_num);
 }
 
-void PubTcpRunner::run() {
+void PubTcpRunner::run()
+{
     if (!endpoint_) {
         throw std::runtime_error("Endpoint not initialized");
     }
-    int num = static_cast<int>(pdu_keys_.size());
+
+    int sent_count = 0;
+    const auto send_start_ns = now_ns();
     for (int i = 0; i < benchmark_config_.try_num; ++i) {
         if (endpoint_->send(pdu_keys_[i], std::span<const std::byte>(buf_.data(), static_cast<size_t>(send_size_))) != HAKO_PDU_ERR_OK) {
             std::cerr << "Failed to send PDU for key: " << pdu_keys_[i].robot << "/" << pdu_keys_[i].pdu << std::endl;
             throw std::runtime_error("Failed to send PDU for key: " + pdu_keys_[i].robot + "/" + pdu_keys_[i].pdu);
         }
-        std::cout << "Sent TCP PDU: robot=" << pdu_keys_[i].robot
-                  << " channel=" << pdu_keys_[i].pdu
+        ++sent_count;
+        std::cout << "BENCH_PUB_EVENT protocol=tcp"
+                  << " robot=" << pdu_keys_[i].robot
+                  << " pdu=" << pdu_keys_[i].pdu
                   << " size=" << send_size_
-                  << " count=" << (i + 1)
+                  << " count=" << sent_count
+                  << " send_ns=" << now_ns()
                   << std::endl;
     }
+    const auto send_end_ns = now_ns();
+    const double send_duration_ms = static_cast<double>(send_end_ns - send_start_ns) / 1000000.0;
+    std::cout << "BENCH_PUB_SUMMARY protocol=tcp"
+              << " expected=" << benchmark_config_.try_num
+              << " sent=" << sent_count
+              << " send_start_ns=" << send_start_ns
+              << " send_end_ns=" << send_end_ns
+              << " send_duration_ms=" << send_duration_ms
+              << std::endl;
 }
 
-void PubTcpRunner::cleanup() {
+void PubTcpRunner::cleanup()
+{
     if (endpoint_) {
         endpoint_->stop();
         endpoint_->close();

--- a/benchmarks/runner/comm/pub_runner_udp.cpp
+++ b/benchmarks/runner/comm/pub_runner_udp.cpp
@@ -27,25 +27,41 @@ void PubUdpRunner::prepare()
     create_send_buffer_for_key(benchmark_config_.try_num);
 }
 
-void PubUdpRunner::run() {
+void PubUdpRunner::run()
+{
     if (!endpoint_) {
         throw std::runtime_error("Endpoint not initialized");
     }
-    int num = static_cast<int>(pdu_keys_.size());
+
+    int sent_count = 0;
+    const auto send_start_ns = now_ns();
     for (int i = 0; i < benchmark_config_.try_num; ++i) {
         if (endpoint_->send(pdu_keys_[i], std::span<const std::byte>(buf_.data(), static_cast<size_t>(send_size_))) != HAKO_PDU_ERR_OK) {
             std::cerr << "Failed to send PDU for key: " << pdu_keys_[i].robot << "/" << pdu_keys_[i].pdu << std::endl;
             throw std::runtime_error("Failed to send PDU for key: " + pdu_keys_[i].robot + "/" + pdu_keys_[i].pdu);
         }
-        std::cout << "Sent UDP PDU: robot=" << pdu_keys_[i].robot
-                  << " channel=" << pdu_keys_[i].pdu
+        ++sent_count;
+        std::cout << "BENCH_PUB_EVENT protocol=udp"
+                  << " robot=" << pdu_keys_[i].robot
+                  << " pdu=" << pdu_keys_[i].pdu
                   << " size=" << send_size_
-                  << " count=" << (i + 1)
+                  << " count=" << sent_count
+                  << " send_ns=" << now_ns()
                   << std::endl;
     }
+    const auto send_end_ns = now_ns();
+    const double send_duration_ms = static_cast<double>(send_end_ns - send_start_ns) / 1000000.0;
+    std::cout << "BENCH_PUB_SUMMARY protocol=udp"
+              << " expected=" << benchmark_config_.try_num
+              << " sent=" << sent_count
+              << " send_start_ns=" << send_start_ns
+              << " send_end_ns=" << send_end_ns
+              << " send_duration_ms=" << send_duration_ms
+              << std::endl;
 }
 
-void PubUdpRunner::cleanup() {
+void PubUdpRunner::cleanup()
+{
     if (endpoint_) {
         endpoint_->stop();
         endpoint_->close();

--- a/benchmarks/runner/comm/runner.hpp
+++ b/benchmarks/runner/comm/runner.hpp
@@ -1,10 +1,16 @@
 #pragma once
 
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <mutex>
+#include <stdexcept>
 #include <string>
 #include <vector>
-#include <memory>
-#include <stdexcept>
-#include <iostream>
 
 #include "nlohmann/json.hpp"
 #include "hakoniwa/pdu/endpoint.hpp"
@@ -17,6 +23,7 @@ enum class CommType {
     TCP,
     UDP
 };
+
 struct BenchmarkConfig {
     std::string benchmark_config_path;
     CommType comm_type;
@@ -27,6 +34,7 @@ struct BenchmarkConfig {
 class Runner {
 public:
     virtual ~Runner() = default;
+
     void load_benchmark_config(const std::string& config_path)
     {
         std::ifstream ifs(config_path);
@@ -67,18 +75,24 @@ public:
             } else {
                 throw std::runtime_error("Benchmark config missing 'config_path': " + config_path);
             }
-            if (config.contains("timeout_sec")) {
-                benchmark_config_.timeout_sec = config["timeout_sec"].get<int>();
-            }
+            benchmark_config_.timeout_sec = config.value("timeout_sec", 30);
         } catch (const nlohmann::json::exception& e) {
             throw std::runtime_error("JSON access failed for benchmark config: " + config_path + ". Details: " + e.what());
         }
     }
+
     virtual void prepare() = 0;
     virtual void run() = 0;
     virtual void cleanup() = 0;
 
 protected:
+    static std::uint64_t now_ns()
+    {
+        return static_cast<std::uint64_t>(
+            std::chrono::duration_cast<std::chrono::nanoseconds>(
+                std::chrono::steady_clock::now().time_since_epoch()).count());
+    }
+
     void prepare_pdudefs(int num)
     {
         auto pdu_def = endpoint_->get_pdu_definition();
@@ -101,13 +115,14 @@ protected:
             });
         }
     }
+
     void create_send_buffer_for_key(int num)
     {
         pdu_keys_.clear();
         pdu_sizes_.clear();
         buf_.clear();
         send_size_ = 0;
-        for (int i = 0; i < benchmark_config_.try_num; ++i) {
+        for (int i = 0; i < num; ++i) {
             hakoniwa::pdu::PduKey key = {"Drone-" + std::to_string(i + 1), "pos"};
 
             size_t pdu_size = endpoint_->get_pdu_size(key);
@@ -150,6 +165,76 @@ protected:
         }
     }
 
+    void reset_receive_benchmark(int expected_count)
+    {
+        std::lock_guard<std::mutex> lock(recv_mutex_);
+        expected_count_.store(expected_count);
+        received_count_.store(0);
+        first_recv_ns_ = 0;
+        last_recv_ns_ = 0;
+    }
+
+    void record_receive_event(const char* protocol,
+                              const hakoniwa::pdu::PduResolvedKey& received_key,
+                              std::span<const std::byte> data)
+    {
+        const auto ts = now_ns();
+        const int count = received_count_.fetch_add(1) + 1;
+        {
+            std::lock_guard<std::mutex> lock(recv_mutex_);
+            if (first_recv_ns_ == 0) {
+                first_recv_ns_ = ts;
+            }
+            last_recv_ns_ = ts;
+        }
+        std::cout
+            << "BENCH_SUB_EVENT protocol=" << protocol
+            << " robot=" << received_key.robot
+            << " channel=" << received_key.channel_id
+            << " size=" << data.size()
+            << " count=" << count
+            << " recv_ns=" << ts
+            << std::endl;
+
+        if (count >= expected_count_.load()) {
+            recv_cv_.notify_all();
+        }
+    }
+
+    void wait_receive_benchmark(const char* protocol)
+    {
+        std::unique_lock<std::mutex> lock(recv_mutex_);
+        const auto timeout = std::chrono::seconds(benchmark_config_.timeout_sec);
+        const bool completed = recv_cv_.wait_for(lock, timeout, [this]() {
+            return received_count_.load() >= expected_count_.load();
+        });
+
+        const int received = received_count_.load();
+        const int expected = expected_count_.load();
+        const auto first = first_recv_ns_;
+        const auto last = last_recv_ns_;
+        const double recv_span_ms = (first != 0 && last >= first)
+            ? static_cast<double>(last - first) / 1000000.0
+            : 0.0;
+
+        std::cout
+            << "BENCH_SUB_SUMMARY protocol=" << protocol
+            << " expected=" << expected
+            << " received=" << received
+            << " first_recv_ns=" << first
+            << " last_recv_ns=" << last
+            << " recv_span_ms=" << recv_span_ms
+            << " completed=" << (completed ? 1 : 0)
+            << std::endl;
+
+        if (!completed) {
+            throw std::runtime_error(
+                std::string("Timed out waiting for ") + protocol +
+                " PDUs: received=" + std::to_string(received) +
+                " expected=" + std::to_string(expected));
+        }
+    }
+
     std::unique_ptr<hakoniwa::pdu::Endpoint> endpoint_;
     std::vector<hakoniwa::pdu::PduKey> pdu_keys_;
     std::vector<size_t> pdu_sizes_;
@@ -157,10 +242,12 @@ protected:
     int send_size_ = 0;
     BenchmarkConfig benchmark_config_;
 
-
     std::atomic<int> expected_count_{0};
     std::atomic<int> received_count_{0};
-
+    std::uint64_t first_recv_ns_ = 0;
+    std::uint64_t last_recv_ns_ = 0;
+    std::mutex recv_mutex_;
+    std::condition_variable recv_cv_;
 };
 
 }

--- a/benchmarks/runner/comm/sub_runner_tcp.cpp
+++ b/benchmarks/runner/comm/sub_runner_tcp.cpp
@@ -1,16 +1,14 @@
 #include "sub_runner.hpp"
 #include "hakoniwa/pdu/endpoint.hpp"
+
 #include <iostream>
-#include <vector>
-#include <thread>
-#include <chrono>
 #include <stdexcept>
 
 namespace benchmarks::runner {
 
-void SubTcpRunner::prepare() {
-    expected_count_.store(benchmark_config_.try_num);
-    received_count_.store(0);
+void SubTcpRunner::prepare()
+{
+    reset_receive_benchmark(benchmark_config_.try_num);
 
     endpoint_ = std::make_unique<hakoniwa::pdu::Endpoint>(
         "sub_runner_tcp",
@@ -37,13 +35,7 @@ void SubTcpRunner::prepare() {
             resolved_key,
             [this](const hakoniwa::pdu::PduResolvedKey& received_key,
                    std::span<const std::byte> data) {
-                const int count = received_count_.fetch_add(1) + 1;
-                std::cout
-                    << "Received TCP PDU: robot=" << received_key.robot
-                    << " channel=" << received_key.channel_id
-                    << " size=" << data.size()
-                    << " count=" << count
-                    << std::endl;
+                record_receive_event("tcp", received_key, data);
             });
     }
 
@@ -54,29 +46,21 @@ void SubTcpRunner::prepare() {
     }
 }
 
-void SubTcpRunner::run() {
+void SubTcpRunner::run()
+{
     if (!endpoint_) {
         throw std::runtime_error("Endpoint not initialized");
     }
 
-    int max_wait_ms = benchmark_config_.timeout_sec * 1000;
-    constexpr int sleep_ms = 10;
-    std::cout << "Waiting for TCP PDUs: expected=" << expected_count_.load() << " timeout=" << benchmark_config_.timeout_sec << " seconds" << std::endl;
-    for (int elapsed_ms = 0; elapsed_ms < max_wait_ms; elapsed_ms += sleep_ms) {
-        if (received_count_.load() >= expected_count_.load()) {
-            return;
-        }
-        endpoint_->process_recv_events();
-        std::this_thread::sleep_for(std::chrono::milliseconds(sleep_ms));
-    }
-
-    std::cerr
-        << "Timed out waiting for TCP PDUs: received=" << received_count_.load()
-        << " expected=" << expected_count_.load()
+    std::cout
+        << "BENCH_SUB_WAIT protocol=tcp expected=" << expected_count_.load()
+        << " timeout_sec=" << benchmark_config_.timeout_sec
         << std::endl;
+    wait_receive_benchmark("tcp");
 }
 
-void SubTcpRunner::cleanup() {
+void SubTcpRunner::cleanup()
+{
     if (endpoint_) {
         endpoint_->stop();
         endpoint_->close();

--- a/benchmarks/runner/comm/sub_runner_udp.cpp
+++ b/benchmarks/runner/comm/sub_runner_udp.cpp
@@ -1,17 +1,14 @@
 #include "sub_runner.hpp"
 #include "hakoniwa/pdu/endpoint.hpp"
 
-#include <chrono>
 #include <iostream>
 #include <stdexcept>
-#include <thread>
 
 namespace benchmarks::runner {
 
 void SubUdpRunner::prepare()
 {
-    expected_count_.store(benchmark_config_.try_num);
-    received_count_.store(0);
+    reset_receive_benchmark(benchmark_config_.try_num);
 
     endpoint_ = std::make_unique<hakoniwa::pdu::Endpoint>(
         "sub_runner_udp",
@@ -38,13 +35,7 @@ void SubUdpRunner::prepare()
             resolved_key,
             [this](const hakoniwa::pdu::PduResolvedKey& received_key,
                    std::span<const std::byte> data) {
-                const int count = received_count_.fetch_add(1) + 1;
-                std::cout
-                    << "Received UDP PDU: robot=" << received_key.robot
-                    << " channel=" << received_key.channel_id
-                    << " size=" << data.size()
-                    << " count=" << count
-                    << std::endl;
+                record_receive_event("udp", received_key, data);
             });
     }
 
@@ -61,21 +52,11 @@ void SubUdpRunner::run()
         throw std::runtime_error("Endpoint not initialized");
     }
 
-    int max_wait_ms = benchmark_config_.timeout_sec * 1000;
-    constexpr int sleep_ms = 10;
-    std::cout << "Waiting for UDP PDUs: expected=" << expected_count_.load() << " timeout=" << benchmark_config_.timeout_sec << " seconds" << std::endl;
-    for (int elapsed_ms = 0; elapsed_ms < max_wait_ms; elapsed_ms += sleep_ms) {
-        if (received_count_.load() >= expected_count_.load()) {
-            return;
-        }
-        endpoint_->process_recv_events();
-        std::this_thread::sleep_for(std::chrono::milliseconds(sleep_ms));
-    }
-
-    std::cerr
-        << "Timed out waiting for UDP PDUs: received=" << received_count_.load()
-        << " expected=" << expected_count_.load()
+    std::cout
+        << "BENCH_SUB_WAIT protocol=udp expected=" << expected_count_.load()
+        << " timeout_sec=" << benchmark_config_.timeout_sec
         << std::endl;
+    wait_receive_benchmark("udp");
 }
 
 void SubUdpRunner::cleanup()


### PR DESCRIPTION
## Summary

- Move UDP/TCP subscriber benchmark completion from polling loops to condition-variable waits driven by receive callbacks
- Record receive-event timestamps in the callback and emit structured `BENCH_SUB_EVENT` / `BENCH_SUB_SUMMARY` logs
- Emit structured publisher timing logs via `BENCH_PUB_EVENT` / `BENCH_PUB_SUMMARY`
- Add shared benchmark timing helpers in the runner base class

## Notes

This keeps the measurement point at the data receive event, while `run()` only waits for completion or timeout.