### PR TITLE
Add benchmark latency log analyzer

### DIFF
--- a/benchmarks/configs/benchmark-tcp.json
+++ b/benchmarks/configs/benchmark-tcp.json
@@ -2,5 +2,6 @@
     "protocol": "tcp",
     "try_num": 1024,
     "timeout_sec": 30,
-    "config_path": "benchmarks/configs"
+    "config_path": "benchmarks/configs",
+    "log_path": "benchmarks/logs/benchmark-tcp.log"
 }

--- a/benchmarks/configs/benchmark-udp.json
+++ b/benchmarks/configs/benchmark-udp.json
@@ -2,5 +2,6 @@
     "protocol": "udp",
     "try_num": 16,
     "timeout_sec": 30,
-    "config_path": "benchmarks/configs"
+    "config_path": "benchmarks/configs",
+    "log_path": "benchmarks/logs/benchmark-udp.log"
 }

--- a/benchmarks/runner/comm/pub_runner_tcp.cpp
+++ b/benchmarks/runner/comm/pub_runner_tcp.cpp
@@ -2,12 +2,15 @@
 #include "hakoniwa/pdu/endpoint.hpp"
 
 #include <iostream>
+#include <sstream>
 #include <stdexcept>
 
 namespace benchmarks::runner {
 
 void PubTcpRunner::prepare()
 {
+    open_benchmark_log("pub");
+
     endpoint_ = std::make_unique<hakoniwa::pdu::Endpoint>(
         "pub_runner_tcp",
         HAKO_PDU_ENDPOINT_DIRECTION_OUT);
@@ -41,23 +44,25 @@ void PubTcpRunner::run()
             throw std::runtime_error("Failed to send PDU for key: " + pdu_keys_[i].robot + "/" + pdu_keys_[i].pdu);
         }
         ++sent_count;
-        std::cout << "BENCH_PUB_EVENT protocol=tcp"
-                  << " robot=" << pdu_keys_[i].robot
-                  << " pdu=" << pdu_keys_[i].pdu
-                  << " size=" << send_size_
-                  << " count=" << sent_count
-                  << " send_ns=" << now_ns()
-                  << std::endl;
+        std::ostringstream oss;
+        oss << "BENCH_PUB_EVENT protocol=tcp"
+            << " robot=" << pdu_keys_[i].robot
+            << " pdu=" << pdu_keys_[i].pdu
+            << " size=" << send_size_
+            << " count=" << sent_count
+            << " send_ns=" << now_ns();
+        write_benchmark_log(oss.str());
     }
     const auto send_end_ns = now_ns();
     const double send_duration_ms = static_cast<double>(send_end_ns - send_start_ns) / 1000000.0;
-    std::cout << "BENCH_PUB_SUMMARY protocol=tcp"
-              << " expected=" << benchmark_config_.try_num
-              << " sent=" << sent_count
-              << " send_start_ns=" << send_start_ns
-              << " send_end_ns=" << send_end_ns
-              << " send_duration_ms=" << send_duration_ms
-              << std::endl;
+    std::ostringstream oss;
+    oss << "BENCH_PUB_SUMMARY protocol=tcp"
+        << " expected=" << benchmark_config_.try_num
+        << " sent=" << sent_count
+        << " send_start_ns=" << send_start_ns
+        << " send_end_ns=" << send_end_ns
+        << " send_duration_ms=" << send_duration_ms;
+    write_benchmark_log(oss.str());
 }
 
 void PubTcpRunner::cleanup()
@@ -67,6 +72,7 @@ void PubTcpRunner::cleanup()
         endpoint_->close();
         endpoint_.reset();
     }
+    close_benchmark_log();
 }
 
 }

--- a/benchmarks/runner/comm/pub_runner_udp.cpp
+++ b/benchmarks/runner/comm/pub_runner_udp.cpp
@@ -2,12 +2,15 @@
 #include "hakoniwa/pdu/endpoint.hpp"
 
 #include <iostream>
+#include <sstream>
 #include <stdexcept>
 
 namespace benchmarks::runner {
 
 void PubUdpRunner::prepare()
 {
+    open_benchmark_log("pub");
+
     endpoint_ = std::make_unique<hakoniwa::pdu::Endpoint>(
         "pub_runner_udp",
         HAKO_PDU_ENDPOINT_DIRECTION_OUT);
@@ -41,23 +44,25 @@ void PubUdpRunner::run()
             throw std::runtime_error("Failed to send PDU for key: " + pdu_keys_[i].robot + "/" + pdu_keys_[i].pdu);
         }
         ++sent_count;
-        std::cout << "BENCH_PUB_EVENT protocol=udp"
-                  << " robot=" << pdu_keys_[i].robot
-                  << " pdu=" << pdu_keys_[i].pdu
-                  << " size=" << send_size_
-                  << " count=" << sent_count
-                  << " send_ns=" << now_ns()
-                  << std::endl;
+        std::ostringstream oss;
+        oss << "BENCH_PUB_EVENT protocol=udp"
+            << " robot=" << pdu_keys_[i].robot
+            << " pdu=" << pdu_keys_[i].pdu
+            << " size=" << send_size_
+            << " count=" << sent_count
+            << " send_ns=" << now_ns();
+        write_benchmark_log(oss.str());
     }
     const auto send_end_ns = now_ns();
     const double send_duration_ms = static_cast<double>(send_end_ns - send_start_ns) / 1000000.0;
-    std::cout << "BENCH_PUB_SUMMARY protocol=udp"
-              << " expected=" << benchmark_config_.try_num
-              << " sent=" << sent_count
-              << " send_start_ns=" << send_start_ns
-              << " send_end_ns=" << send_end_ns
-              << " send_duration_ms=" << send_duration_ms
-              << std::endl;
+    std::ostringstream oss;
+    oss << "BENCH_PUB_SUMMARY protocol=udp"
+        << " expected=" << benchmark_config_.try_num
+        << " sent=" << sent_count
+        << " send_start_ns=" << send_start_ns
+        << " send_end_ns=" << send_end_ns
+        << " send_duration_ms=" << send_duration_ms;
+    write_benchmark_log(oss.str());
 }
 
 void PubUdpRunner::cleanup()
@@ -67,6 +72,7 @@ void PubUdpRunner::cleanup()
         endpoint_->close();
         endpoint_.reset();
     }
+    close_benchmark_log();
 }
 
 }

--- a/benchmarks/runner/comm/runner.hpp
+++ b/benchmarks/runner/comm/runner.hpp
@@ -4,10 +4,12 @@
 #include <chrono>
 #include <condition_variable>
 #include <cstdint>
+#include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <memory>
 #include <mutex>
+#include <sstream>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -26,6 +28,8 @@ enum class CommType {
 
 struct BenchmarkConfig {
     std::string benchmark_config_path;
+    std::string protocol;
+    std::string log_path;
     CommType comm_type;
     int try_num;
     int timeout_sec;
@@ -52,6 +56,7 @@ public:
         try {
             if (config.contains("protocol")) {
                 std::string protocol = config["protocol"].get<std::string>();
+                benchmark_config_.protocol = protocol;
                 if (protocol == "shm") {
                     benchmark_config_.comm_type = CommType::SHM;
                 } else if (protocol == "tcp") {
@@ -76,6 +81,9 @@ public:
                 throw std::runtime_error("Benchmark config missing 'config_path': " + config_path);
             }
             benchmark_config_.timeout_sec = config.value("timeout_sec", 30);
+            benchmark_config_.log_path = config.value(
+                "log_path",
+                benchmark_config_.benchmark_config_path + "/benchmark-" + benchmark_config_.protocol + ".log");
         } catch (const nlohmann::json::exception& e) {
             throw std::runtime_error("JSON access failed for benchmark config: " + config_path + ". Details: " + e.what());
         }
@@ -91,6 +99,58 @@ protected:
         return static_cast<std::uint64_t>(
             std::chrono::duration_cast<std::chrono::nanoseconds>(
                 std::chrono::steady_clock::now().time_since_epoch()).count());
+    }
+
+    std::filesystem::path log_path_for_role(const char* role) const
+    {
+        std::filesystem::path base(benchmark_config_.log_path);
+        const auto parent = base.parent_path();
+        const auto stem = base.stem().string();
+        const auto ext = base.extension().string();
+
+        std::string filename;
+        if (!stem.empty() && ext == ".log") {
+            filename = stem + "_" + role + ext;
+        } else if (!base.filename().empty()) {
+            filename = base.filename().string() + "_" + role + ".log";
+        } else {
+            filename = std::string("benchmark-") + benchmark_config_.protocol + "_" + role + ".log";
+        }
+        return parent.empty() ? std::filesystem::path(filename) : parent / filename;
+    }
+
+    void open_benchmark_log(const char* role)
+    {
+        const auto path = log_path_for_role(role);
+        const auto parent = path.parent_path();
+        if (!parent.empty()) {
+            std::filesystem::create_directories(parent);
+        }
+
+        benchmark_log_.open(path, std::ios::out | std::ios::trunc);
+        if (!benchmark_log_.is_open()) {
+            throw std::runtime_error("Failed to open benchmark log file: " + path.string());
+        }
+        std::cout << "Benchmark log: " << path.string() << std::endl;
+    }
+
+    void close_benchmark_log()
+    {
+        std::lock_guard<std::mutex> lock(log_mutex_);
+        if (benchmark_log_.is_open()) {
+            benchmark_log_.flush();
+            benchmark_log_.close();
+        }
+    }
+
+    void write_benchmark_log(const std::string& line)
+    {
+        std::lock_guard<std::mutex> lock(log_mutex_);
+        if (benchmark_log_.is_open()) {
+            benchmark_log_ << line << std::endl;
+        } else {
+            std::cout << line << std::endl;
+        }
     }
 
     void prepare_pdudefs(int num)
@@ -187,14 +247,15 @@ protected:
             }
             last_recv_ns_ = ts;
         }
-        std::cout
-            << "BENCH_SUB_EVENT protocol=" << protocol
+
+        std::ostringstream oss;
+        oss << "BENCH_SUB_EVENT protocol=" << protocol
             << " robot=" << received_key.robot
             << " channel=" << received_key.channel_id
             << " size=" << data.size()
             << " count=" << count
-            << " recv_ns=" << ts
-            << std::endl;
+            << " recv_ns=" << ts;
+        write_benchmark_log(oss.str());
 
         if (count >= expected_count_.load()) {
             recv_cv_.notify_all();
@@ -217,15 +278,15 @@ protected:
             ? static_cast<double>(last - first) / 1000000.0
             : 0.0;
 
-        std::cout
-            << "BENCH_SUB_SUMMARY protocol=" << protocol
+        std::ostringstream oss;
+        oss << "BENCH_SUB_SUMMARY protocol=" << protocol
             << " expected=" << expected
             << " received=" << received
             << " first_recv_ns=" << first
             << " last_recv_ns=" << last
             << " recv_span_ms=" << recv_span_ms
-            << " completed=" << (completed ? 1 : 0)
-            << std::endl;
+            << " completed=" << (completed ? 1 : 0);
+        write_benchmark_log(oss.str());
 
         if (!completed) {
             throw std::runtime_error(
@@ -248,6 +309,8 @@ protected:
     std::uint64_t last_recv_ns_ = 0;
     std::mutex recv_mutex_;
     std::condition_variable recv_cv_;
+    std::ofstream benchmark_log_;
+    std::mutex log_mutex_;
 };
 
 }

--- a/benchmarks/runner/comm/runner.hpp
+++ b/benchmarks/runner/comm/runner.hpp
@@ -121,36 +121,47 @@ protected:
 
     void open_benchmark_log(const char* role)
     {
-        const auto path = log_path_for_role(role);
-        const auto parent = path.parent_path();
+        benchmark_log_path_ = log_path_for_role(role);
+        const auto parent = benchmark_log_path_.parent_path();
         if (!parent.empty()) {
             std::filesystem::create_directories(parent);
         }
 
-        benchmark_log_.open(path, std::ios::out | std::ios::trunc);
-        if (!benchmark_log_.is_open()) {
-            throw std::runtime_error("Failed to open benchmark log file: " + path.string());
+        {
+            std::lock_guard<std::mutex> lock(log_mutex_);
+            benchmark_log_lines_.clear();
         }
-        std::cout << "Benchmark log: " << path.string() << std::endl;
+        std::cout << "Benchmark log: " << benchmark_log_path_.string() << std::endl;
     }
 
     void close_benchmark_log()
     {
-        std::lock_guard<std::mutex> lock(log_mutex_);
-        if (benchmark_log_.is_open()) {
-            benchmark_log_.flush();
-            benchmark_log_.close();
+        std::vector<std::string> lines;
+        {
+            std::lock_guard<std::mutex> lock(log_mutex_);
+            lines.swap(benchmark_log_lines_);
+        }
+
+        if (benchmark_log_path_.empty()) {
+            for (const auto& line : lines) {
+                std::cout << line << std::endl;
+            }
+            return;
+        }
+
+        std::ofstream ofs(benchmark_log_path_, std::ios::out | std::ios::trunc);
+        if (!ofs.is_open()) {
+            throw std::runtime_error("Failed to open benchmark log file: " + benchmark_log_path_.string());
+        }
+        for (const auto& line : lines) {
+            ofs << line << '\n';
         }
     }
 
     void write_benchmark_log(const std::string& line)
     {
         std::lock_guard<std::mutex> lock(log_mutex_);
-        if (benchmark_log_.is_open()) {
-            benchmark_log_ << line << std::endl;
-        } else {
-            std::cout << line << std::endl;
-        }
+        benchmark_log_lines_.push_back(line);
     }
 
     void prepare_pdudefs(int num)
@@ -309,7 +320,8 @@ protected:
     std::uint64_t last_recv_ns_ = 0;
     std::mutex recv_mutex_;
     std::condition_variable recv_cv_;
-    std::ofstream benchmark_log_;
+    std::filesystem::path benchmark_log_path_;
+    std::vector<std::string> benchmark_log_lines_;
     std::mutex log_mutex_;
 };
 

--- a/benchmarks/runner/comm/sub_runner_tcp.cpp
+++ b/benchmarks/runner/comm/sub_runner_tcp.cpp
@@ -2,12 +2,14 @@
 #include "hakoniwa/pdu/endpoint.hpp"
 
 #include <iostream>
+#include <sstream>
 #include <stdexcept>
 
 namespace benchmarks::runner {
 
 void SubTcpRunner::prepare()
 {
+    open_benchmark_log("sub");
     reset_receive_benchmark(benchmark_config_.try_num);
 
     endpoint_ = std::make_unique<hakoniwa::pdu::Endpoint>(
@@ -52,10 +54,10 @@ void SubTcpRunner::run()
         throw std::runtime_error("Endpoint not initialized");
     }
 
-    std::cout
-        << "BENCH_SUB_WAIT protocol=tcp expected=" << expected_count_.load()
-        << " timeout_sec=" << benchmark_config_.timeout_sec
-        << std::endl;
+    std::ostringstream oss;
+    oss << "BENCH_SUB_WAIT protocol=tcp expected=" << expected_count_.load()
+        << " timeout_sec=" << benchmark_config_.timeout_sec;
+    write_benchmark_log(oss.str());
     wait_receive_benchmark("tcp");
 }
 
@@ -66,6 +68,7 @@ void SubTcpRunner::cleanup()
         endpoint_->close();
         endpoint_.reset();
     }
+    close_benchmark_log();
 }
 
 }

--- a/benchmarks/runner/comm/sub_runner_udp.cpp
+++ b/benchmarks/runner/comm/sub_runner_udp.cpp
@@ -2,12 +2,14 @@
 #include "hakoniwa/pdu/endpoint.hpp"
 
 #include <iostream>
+#include <sstream>
 #include <stdexcept>
 
 namespace benchmarks::runner {
 
 void SubUdpRunner::prepare()
 {
+    open_benchmark_log("sub");
     reset_receive_benchmark(benchmark_config_.try_num);
 
     endpoint_ = std::make_unique<hakoniwa::pdu::Endpoint>(
@@ -52,10 +54,10 @@ void SubUdpRunner::run()
         throw std::runtime_error("Endpoint not initialized");
     }
 
-    std::cout
-        << "BENCH_SUB_WAIT protocol=udp expected=" << expected_count_.load()
-        << " timeout_sec=" << benchmark_config_.timeout_sec
-        << std::endl;
+    std::ostringstream oss;
+    oss << "BENCH_SUB_WAIT protocol=udp expected=" << expected_count_.load()
+        << " timeout_sec=" << benchmark_config_.timeout_sec;
+    write_benchmark_log(oss.str());
     wait_receive_benchmark("udp");
 }
 
@@ -66,6 +68,7 @@ void SubUdpRunner::cleanup()
         endpoint_->close();
         endpoint_.reset();
     }
+    close_benchmark_log();
 }
 
 }

--- a/benchmarks/tools/measure_latency.py
+++ b/benchmarks/tools/measure_latency.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Analyze Hakoniwa PDU endpoint benchmark logs.
+
+This tool reads publisher/subscriber logs containing BENCH_* records and reports
+batch-level timing such as send start to final receive time.
+
+Example:
+    python3 benchmarks/tools/measure_latency.py \
+        --pub-log pub.log \
+        --sub-log sub.log
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, Optional
+
+
+@dataclass
+class PubSummary:
+    protocol: str
+    expected: int
+    sent: int
+    send_start_ns: int
+    send_end_ns: int
+    send_duration_ms: float
+
+
+@dataclass
+class SubSummary:
+    protocol: str
+    expected: int
+    received: int
+    first_recv_ns: int
+    last_recv_ns: int
+    recv_span_ms: float
+    completed: bool
+
+
+def parse_kv_line(line: str) -> tuple[str, Dict[str, str]] | None:
+    line = line.strip()
+    if not line.startswith("BENCH_"):
+        return None
+
+    parts = line.split()
+    if not parts:
+        return None
+
+    record_type = parts[0]
+    values: Dict[str, str] = {}
+    for part in parts[1:]:
+        if "=" not in part:
+            continue
+        key, value = part.split("=", 1)
+        values[key] = value
+    return record_type, values
+
+
+def iter_records(path: Path) -> Iterable[tuple[str, Dict[str, str]]]:
+    with path.open("r", encoding="utf-8") as f:
+        for line in f:
+            parsed = parse_kv_line(line)
+            if parsed is not None:
+                yield parsed
+
+
+def read_pub_summary(path: Path) -> PubSummary:
+    summary: Optional[PubSummary] = None
+    for record_type, values in iter_records(path):
+        if record_type != "BENCH_PUB_SUMMARY":
+            continue
+        summary = PubSummary(
+            protocol=values["protocol"],
+            expected=int(values["expected"]),
+            sent=int(values["sent"]),
+            send_start_ns=int(values["send_start_ns"]),
+            send_end_ns=int(values["send_end_ns"]),
+            send_duration_ms=float(values["send_duration_ms"]),
+        )
+    if summary is None:
+        raise RuntimeError(f"BENCH_PUB_SUMMARY not found: {path}")
+    return summary
+
+
+def read_sub_summary(path: Path) -> SubSummary:
+    summary: Optional[SubSummary] = None
+    for record_type, values in iter_records(path):
+        if record_type != "BENCH_SUB_SUMMARY":
+            continue
+        summary = SubSummary(
+            protocol=values["protocol"],
+            expected=int(values["expected"]),
+            received=int(values["received"]),
+            first_recv_ns=int(values["first_recv_ns"]),
+            last_recv_ns=int(values["last_recv_ns"]),
+            recv_span_ms=float(values["recv_span_ms"]),
+            completed=(values["completed"] == "1"),
+        )
+    if summary is None:
+        raise RuntimeError(f"BENCH_SUB_SUMMARY not found: {path}")
+    return summary
+
+
+def ns_to_ms(delta_ns: int) -> float:
+    return delta_ns / 1_000_000.0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Compute batch latency from Hakoniwa PDU endpoint benchmark logs."
+    )
+    parser.add_argument("--pub-log", required=True, type=Path, help="Publisher log file")
+    parser.add_argument("--sub-log", required=True, type=Path, help="Subscriber log file")
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Return non-zero when sent/received/completed counts do not match expected values",
+    )
+    args = parser.parse_args()
+
+    pub = read_pub_summary(args.pub_log)
+    sub = read_sub_summary(args.sub_log)
+
+    if pub.protocol != sub.protocol:
+        raise RuntimeError(f"Protocol mismatch: pub={pub.protocol} sub={sub.protocol}")
+
+    end_to_end_ms = ns_to_ms(sub.last_recv_ns - pub.send_start_ns)
+    first_receive_latency_ms = ns_to_ms(sub.first_recv_ns - pub.send_start_ns) if sub.first_recv_ns else 0.0
+    tail_after_send_ms = ns_to_ms(sub.last_recv_ns - pub.send_end_ns)
+    loss_count = pub.sent - sub.received
+    loss_rate = (loss_count / pub.sent) if pub.sent > 0 else 0.0
+
+    print(f"protocol={pub.protocol}")
+    print(f"expected={pub.expected}")
+    print(f"sent={pub.sent}")
+    print(f"received={sub.received}")
+    print(f"completed={1 if sub.completed else 0}")
+    print(f"loss_count={loss_count}")
+    print(f"loss_rate={loss_rate:.6f}")
+    print(f"send_duration_ms={pub.send_duration_ms:.6f}")
+    print(f"recv_span_ms={sub.recv_span_ms:.6f}")
+    print(f"first_receive_latency_ms={first_receive_latency_ms:.6f}")
+    print(f"end_to_end_ms={end_to_end_ms:.6f}")
+    print(f"tail_after_send_ms={tail_after_send_ms:.6f}")
+
+    if args.strict:
+        if pub.sent != pub.expected or sub.received != sub.expected or not sub.completed:
+            return 2
+        if pub.expected != sub.expected:
+            return 2
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception as e:
+        print(f"error: {e}", file=sys.stderr)
+        raise SystemExit(1)


### PR DESCRIPTION
## Summary

- Add `benchmarks/tools/measure_latency.py`
- Parse `BENCH_PUB_SUMMARY` and `BENCH_SUB_SUMMARY` records
- Report batch end-to-end timing from publisher send start to subscriber final receive time
- Report send duration, receive span, first receive latency, tail-after-send time, and loss count/rate

## Usage

```bash
python3 benchmarks/tools/measure_latency.py \
  --pub-log pub.log \
  --sub-log sub.log
```

Use `--strict` to return non-zero when counts do not match or the subscriber did not complete.