### PR TITLE
Generate SHM subscriber benchmark config from try count

### DIFF
--- a/benchmarks/runner/comm/pub_runner.hpp
+++ b/benchmarks/runner/comm/pub_runner.hpp
@@ -1,10 +1,11 @@
 #pragma once
 
 #include "runner.hpp"
+#include "shm_runner.hpp"
 
 namespace benchmarks::runner {
 
-class PubShmRunner : public Runner {
+class PubShmRunner : public ShmRunnerBase {
 public:
     void prepare() override;
     void run() override;

--- a/benchmarks/runner/comm/shm_runner.cpp
+++ b/benchmarks/runner/comm/shm_runner.cpp
@@ -1,0 +1,75 @@
+#include "shm_runner.hpp"
+
+#include "nlohmann/json.hpp"
+
+#include <filesystem>
+#include <fstream>
+#include <stdexcept>
+
+namespace benchmarks::runner {
+
+std::filesystem::path ShmRunnerBase::generate_shm_endpoint_config(
+    const std::string& role,
+    const std::string& endpoint_name,
+    const std::string& comm_name,
+    bool notify_on_recv)
+{
+    const std::filesystem::path generated_root =
+        std::filesystem::path(benchmark_config_.benchmark_config_path) / "generated" / "shm";
+    const std::filesystem::path endpoint_dir =
+        generated_root / "endpoint" / role;
+    const std::filesystem::path comm_dir = endpoint_dir / "comm";
+
+    std::filesystem::create_directories(comm_dir);
+
+    nlohmann::json comm_config;
+    comm_config["protocol"] = "shm";
+    comm_config["impl_type"] = "callback";
+    comm_config["name"] = comm_name;
+    comm_config["direction"] = "inout";
+    comm_config["io"]["robots"] = nlohmann::json::array();
+
+    for (int i = 0; i < benchmark_config_.try_num; ++i) {
+        nlohmann::json pdu_item;
+        pdu_item["name"] = "pos";
+        if (notify_on_recv) {
+            pdu_item["notify_on_recv"] = true;
+        }
+
+        comm_config["io"]["robots"].push_back({
+            {"name", "Drone-" + std::to_string(i + 1)},
+            {"pdu", nlohmann::json::array({pdu_item})}
+        });
+    }
+
+    const std::filesystem::path comm_config_path =
+        comm_dir / (role + std::string("_shm_comm.json"));
+    {
+        std::ofstream ofs(comm_config_path, std::ios::out | std::ios::trunc);
+        if (!ofs.is_open()) {
+            throw std::runtime_error(
+                "Failed to open generated SHM comm config: " + comm_config_path.string());
+        }
+        ofs << comm_config.dump(2) << std::endl;
+    }
+
+    nlohmann::json endpoint_config;
+    endpoint_config["name"] = endpoint_name;
+    endpoint_config["cache"] = "../../../../endpoint/cache/buffer.json";
+    endpoint_config["comm"] = "comm/" + role + std::string("_shm_comm.json");
+
+    const std::filesystem::path endpoint_config_path =
+        endpoint_dir / (role + std::string("_shm.json"));
+    {
+        std::ofstream ofs(endpoint_config_path, std::ios::out | std::ios::trunc);
+        if (!ofs.is_open()) {
+            throw std::runtime_error(
+                "Failed to open generated SHM endpoint config: " + endpoint_config_path.string());
+        }
+        ofs << endpoint_config.dump(2) << std::endl;
+    }
+
+    return endpoint_config_path;
+}
+
+}

--- a/benchmarks/runner/comm/shm_runner.hpp
+++ b/benchmarks/runner/comm/shm_runner.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "runner.hpp"
+
+#include <filesystem>
+#include <string>
+
+namespace benchmarks::runner {
+
+class ShmRunnerBase : public Runner {
+protected:
+    std::filesystem::path generate_shm_endpoint_config(
+        const std::string& role,
+        const std::string& endpoint_name,
+        const std::string& comm_name,
+        bool notify_on_recv);
+};
+
+}

--- a/benchmarks/runner/comm/sub_runner.hpp
+++ b/benchmarks/runner/comm/sub_runner.hpp
@@ -1,13 +1,14 @@
 #pragma once
 
 #include "runner.hpp"
+#include "shm_runner.hpp"
 #include "hako_asset.h"
 
 #include <atomic>
 
 namespace benchmarks::runner {
 
-class SubShmRunner : public Runner {
+class SubShmRunner : public ShmRunnerBase {
 public:
     void prepare() override;
     void run() override;

--- a/benchmarks/runner/comm/sub_runner_shm.cpp
+++ b/benchmarks/runner/comm/sub_runner_shm.cpp
@@ -1,7 +1,79 @@
 #include "sub_runner.hpp"
 #include "hako_conductor.h"
+#include "nlohmann/json.hpp"
+
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <stdexcept>
 
 namespace benchmarks::runner {
+
+namespace {
+
+std::filesystem::path generate_shm_subscriber_config(
+    const std::string& config_path,
+    int try_num)
+{
+    const std::filesystem::path generated_root =
+        std::filesystem::path(config_path) / "generated" / "shm";
+    const std::filesystem::path endpoint_dir =
+        generated_root / "endpoint" / "subscriber";
+    const std::filesystem::path comm_dir = endpoint_dir / "comm";
+
+    std::filesystem::create_directories(comm_dir);
+
+    nlohmann::json comm_config;
+    comm_config["protocol"] = "shm";
+    comm_config["impl_type"] = "callback";
+    comm_config["name"] = "shm_subscriber";
+    comm_config["direction"] = "inout";
+    comm_config["io"]["robots"] = nlohmann::json::array();
+
+    for (int i = 0; i < try_num; ++i) {
+        nlohmann::json pdu = nlohmann::json::array({
+            {
+                {"name", "pos"},
+                {"notify_on_recv", true}
+            }
+        });
+        comm_config["io"]["robots"].push_back({
+            {"name", "Drone-" + std::to_string(i + 1)},
+            {"pdu", pdu}
+        });
+    }
+
+    const std::filesystem::path comm_config_path =
+        comm_dir / "subscriber_shm_comm.json";
+    {
+        std::ofstream ofs(comm_config_path, std::ios::out | std::ios::trunc);
+        if (!ofs.is_open()) {
+            throw std::runtime_error(
+                "Failed to open generated SHM comm config: " + comm_config_path.string());
+        }
+        ofs << comm_config.dump(2) << std::endl;
+    }
+
+    nlohmann::json endpoint_config;
+    endpoint_config["name"] = "ep_shm_subscriber";
+    endpoint_config["cache"] = "../../../../endpoint/cache/buffer.json";
+    endpoint_config["comm"] = "comm/subscriber_shm_comm.json";
+
+    const std::filesystem::path endpoint_config_path =
+        endpoint_dir / "subscriber_shm.json";
+    {
+        std::ofstream ofs(endpoint_config_path, std::ios::out | std::ios::trunc);
+        if (!ofs.is_open()) {
+            throw std::runtime_error(
+                "Failed to open generated SHM endpoint config: " + endpoint_config_path.string());
+        }
+        ofs << endpoint_config.dump(2) << std::endl;
+    }
+
+    return endpoint_config_path;
+}
+
+} // namespace
 
 void SubShmRunner::on_recv(int recv_event_id)
 {
@@ -40,6 +112,10 @@ void SubShmRunner::prepare() {
     open_benchmark_log("sub");
     reset_receive_benchmark(benchmark_config_.try_num);
 
+    const auto endpoint_config_path = generate_shm_subscriber_config(
+        benchmark_config_.benchmark_config_path,
+        benchmark_config_.try_num);
+
     hako_conductor_start(benchmark_config_.delta_time_usec, benchmark_config_.max_delay_usec);
     std::string asset_name = "sub_runner_shm_asset";
     std::string pdudef_path = benchmark_config_.benchmark_config_path + "/pdu/pdudef.json";
@@ -52,10 +128,9 @@ void SubShmRunner::prepare() {
         "sub_runner_shm",
         HAKO_PDU_ENDPOINT_DIRECTION_IN);
 
-    std::string endpoint_config_path = benchmark_config_.benchmark_config_path + "/endpoint/subscriber/subscriber_shm.json";
-    if (endpoint_->open(endpoint_config_path) != HAKO_PDU_ERR_OK) {
+    if (endpoint_->open(endpoint_config_path.string()) != HAKO_PDU_ERR_OK) {
         endpoint_.reset();
-        throw std::runtime_error("Failed to open SHM subscriber endpoint: " + endpoint_config_path);
+        throw std::runtime_error("Failed to open SHM subscriber endpoint: " + endpoint_config_path.string());
     }
     prepare_pdudefs(benchmark_config_.try_num);
     for (int i = 0; i < benchmark_config_.try_num; ++i) {

--- a/benchmarks/runner/comm/sub_runner_shm.cpp
+++ b/benchmarks/runner/comm/sub_runner_shm.cpp
@@ -1,79 +1,10 @@
 #include "sub_runner.hpp"
 #include "hako_conductor.h"
-#include "nlohmann/json.hpp"
 
-#include <filesystem>
-#include <fstream>
 #include <iostream>
 #include <stdexcept>
 
 namespace benchmarks::runner {
-
-namespace {
-
-std::filesystem::path generate_shm_subscriber_config(
-    const std::string& config_path,
-    int try_num)
-{
-    const std::filesystem::path generated_root =
-        std::filesystem::path(config_path) / "generated" / "shm";
-    const std::filesystem::path endpoint_dir =
-        generated_root / "endpoint" / "subscriber";
-    const std::filesystem::path comm_dir = endpoint_dir / "comm";
-
-    std::filesystem::create_directories(comm_dir);
-
-    nlohmann::json comm_config;
-    comm_config["protocol"] = "shm";
-    comm_config["impl_type"] = "callback";
-    comm_config["name"] = "shm_subscriber";
-    comm_config["direction"] = "inout";
-    comm_config["io"]["robots"] = nlohmann::json::array();
-
-    for (int i = 0; i < try_num; ++i) {
-        nlohmann::json pdu = nlohmann::json::array({
-            {
-                {"name", "pos"},
-                {"notify_on_recv", true}
-            }
-        });
-        comm_config["io"]["robots"].push_back({
-            {"name", "Drone-" + std::to_string(i + 1)},
-            {"pdu", pdu}
-        });
-    }
-
-    const std::filesystem::path comm_config_path =
-        comm_dir / "subscriber_shm_comm.json";
-    {
-        std::ofstream ofs(comm_config_path, std::ios::out | std::ios::trunc);
-        if (!ofs.is_open()) {
-            throw std::runtime_error(
-                "Failed to open generated SHM comm config: " + comm_config_path.string());
-        }
-        ofs << comm_config.dump(2) << std::endl;
-    }
-
-    nlohmann::json endpoint_config;
-    endpoint_config["name"] = "ep_shm_subscriber";
-    endpoint_config["cache"] = "../../../../endpoint/cache/buffer.json";
-    endpoint_config["comm"] = "comm/subscriber_shm_comm.json";
-
-    const std::filesystem::path endpoint_config_path =
-        endpoint_dir / "subscriber_shm.json";
-    {
-        std::ofstream ofs(endpoint_config_path, std::ios::out | std::ios::trunc);
-        if (!ofs.is_open()) {
-            throw std::runtime_error(
-                "Failed to open generated SHM endpoint config: " + endpoint_config_path.string());
-        }
-        ofs << endpoint_config.dump(2) << std::endl;
-    }
-
-    return endpoint_config_path;
-}
-
-} // namespace
 
 void SubShmRunner::on_recv(int recv_event_id)
 {
@@ -100,21 +31,27 @@ int SubShmRunner::my_on_manual_timing_control(hako_asset_context_t* context)
     return 0;
 }
 
-static hako_asset_callbacks_t my_callback = {
-    .on_initialize = SubShmRunner::my_on_initialize,
-    .on_manual_timing_control = SubShmRunner::my_on_manual_timing_control,
-    .on_simulation_step = NULL,
-    .on_reset = SubShmRunner::my_on_reset
-};
+static hako_asset_callbacks_t create_shm_callbacks()
+{
+    hako_asset_callbacks_t callbacks{};
+    callbacks.on_initialize = SubShmRunner::my_on_initialize;
+    callbacks.on_manual_timing_control = SubShmRunner::my_on_manual_timing_control;
+    callbacks.on_reset = SubShmRunner::my_on_reset;
+    return callbacks;
+}
+
+static hako_asset_callbacks_t my_callback = create_shm_callbacks();
 
 void SubShmRunner::prepare() {
     set_instance(this);
     open_benchmark_log("sub");
     reset_receive_benchmark(benchmark_config_.try_num);
 
-    const auto endpoint_config_path = generate_shm_subscriber_config(
-        benchmark_config_.benchmark_config_path,
-        benchmark_config_.try_num);
+    const auto endpoint_config_path = generate_shm_endpoint_config(
+        "subscriber",
+        "ep_shm_subscriber",
+        "shm_subscriber",
+        true);
 
     hako_conductor_start(benchmark_config_.delta_time_usec, benchmark_config_.max_delay_usec);
     std::string asset_name = "sub_runner_shm_asset";


### PR DESCRIPTION
## Summary

- Generate SHM subscriber endpoint/comm config from `try_num` in the benchmark runner
- Avoid manually expanding `subscriber_shm_comm.json` robots list for benchmark counts
- Keep generated config under `benchmarks/configs/generated/shm/...`
- Continue using the existing base PDU definition and runtime PDU definition expansion

## Notes

`PduCommShm::open()` reads the comm JSON directly, so SHM notify targets must be expanded before `endpoint_->open()`. This PR generates an endpoint config and SHM comm config in the runner before opening the endpoint.

This is an initial SHM subscriber step. `on_recv()` still needs to be wired to the endpoint receive processing path once the SHM receive-event API path is confirmed.