### PR TITLE
Harden manifest build flow for ARM64 and Zenoh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,47 @@ jobs:
           python3 python/test/test_c_endpoint_smoke.py
           python3 python/test/test_endpoint_container_smoke.py
 
+  linux-zenoh-shared:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y g++-12 cmake libboost-dev
+
+      - name: Update Compiler Alternatives
+        run: |
+          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-12 12
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check Rust toolchain
+        run: |
+          cargo --version
+          rustc --version
+
+      - name: Build shared endpoint with Zenoh
+        run: |
+          cmake -S . -B build-zenoh \
+            -DBUILD_SHARED_LIBS=ON \
+            -DHAKO_PDU_ENDPOINT_ENABLE_HAKONIWA_CORE=OFF \
+            -DHAKO_PDU_ENDPOINT_ENABLE_ZENOH=ON \
+            -DHAKO_PDU_ENDPOINT_BUILD_TESTS=OFF \
+            -DHAKO_PDU_ENDPOINT_BUILD_EXAMPLES=OFF \
+            -DHAKO_PDU_ENDPOINT_BUILD_TOOLS=OFF \
+            -DHAKO_PDU_ENDPOINT_BUILD_BENCHMARKS=OFF
+          cmake --build build-zenoh --config Release --target hakoniwa_pdu_endpoint
+
+      - name: Verify zenoh-c is not a dynamic dependency
+        run: |
+          if readelf -d build-zenoh/src/libhakoniwa_pdu_endpoint.so | grep -q 'libzenohc.so'; then
+            echo "Unexpected dynamic libzenohc.so dependency"
+            readelf -d build-zenoh/src/libhakoniwa_pdu_endpoint.so
+            exit 1
+          fi
+          readelf -d build-zenoh/src/libhakoniwa_pdu_endpoint.so | grep NEEDED || true
+
   macos-python:
     runs-on: macos-latest
     steps:

--- a/docs/build-architecture.md
+++ b/docs/build-architecture.md
@@ -69,7 +69,13 @@ OS-specific logic is limited to toolchain and runtime discovery:
 
 - Windows: MSVC/vswhere, optional vcpkg toolchain, DLL search directories
 - macOS: dylib naming/search
-- Linux: shared-object naming/search
+- Linux: shared-object naming/search and native library architecture directories
+
+Linux `aarch64` and `arm64` are normalized to the same `arm64` platform architecture by
+the resolver. A missing prebuilt Linux ARM64 release bundle is a packaging limitation,
+not a separate build model: source builds still use the same manifest/configure flow.
+Architecture-specific system library fallbacks must use CMake platform information such
+as `CMAKE_LIBRARY_ARCHITECTURE` rather than hard-coded x86_64 paths.
 
 The build model itself does not change by OS.
 
@@ -158,6 +164,18 @@ When enabled, the root is resolved from, in order:
 These map to the corresponding optional native transports. They are independent from
 Python and Hakoniwa Core.
 
+`features.zenoh: true` also introduces a Rust toolchain requirement because the vendored
+`zenoh-c` implementation is built from Rust. `tools/hako.py doctor` therefore checks that
+both `cargo` and `rustc` are available before build. Direct-CMake users receive the same
+preflight during CMake configure.
+
+The Zenoh dependency is treated as an implementation detail of pdu-endpoint. When the
+endpoint itself is built as a shared library (including the Python/cffi flow), the build
+prefers the vendored `zenohc::static` target rather than inheriting `BUILD_SHARED_LIBS`
+through `zenohc::lib`. This avoids a runtime `libzenohc.so` dependency that can collide
+with another Zenoh runtime in the same process, notably the vendor library used by ROS 2
+`rmw_zenoh_cpp`.
+
 ### Python binding
 
 `bindings.python: true` is the default manifest behavior. The configurator:
@@ -232,7 +250,7 @@ Phase 2:
 
 - move CI Python build jobs to the manifest flow on all supported OSes;
 - reduce duplicated feature-resolution logic in shell/PowerShell helpers;
-- add more executable validation for feature combinations.
+- add more executable validation for feature combinations, including shared Python/Zenoh linkage.
 
 Phase 3:
 

--- a/install-python.bash
+++ b/install-python.bash
@@ -31,11 +31,17 @@ Env:
   PREFIX_DIR=$HOME/.local/lib/hakoniwa-pdu-endpoint
   HAKO_PDU_ENDPOINT_VERSION=v1.0.0
   HAKO_PDU_ENDPOINT_RUNTIME_URL=https://...
+  HAKO_PDU_ENDPOINT_ARCHIVE_BASENAME=...
   RUN_SMOKE_TEST=1
 
 Examples:
   bash install-python.bash
   MODE=use-existing PREFIX_DIR=$HOME/.local/lib/hakoniwa-pdu-endpoint bash install-python.bash
+
+Linux ARM64 / aarch64:
+  Prebuilt runtime bundles are not published yet. Use the manifest-driven
+  source build (`python tools/hako.py doctor`, then `python tools/hako.py build`)
+  and `install-python-runtime.bash` instead of bootstrap mode.
 EOF
 }
 
@@ -46,12 +52,26 @@ fi
 
 case "$(uname -s)" in
   Linux)
-    if [[ -z "${ARCHIVE_BASENAME}" ]]; then
-      ARCHIVE_BASENAME="hakoniwa-pdu-endpoint-linux-x86_64-cp312.zip"
+    if [[ -z "${ARCHIVE_BASENAME}" && -z "${RUNTIME_URL}" ]]; then
+      case "$(uname -m)" in
+        x86_64|amd64)
+          ARCHIVE_BASENAME="hakoniwa-pdu-endpoint-linux-x86_64-cp312.zip"
+          ;;
+        aarch64|arm64)
+          if [[ "${MODE}" == "bootstrap" ]]; then
+            die "No prebuilt Linux ARM64 runtime bundle is published. Use the manifest-driven source build: 'python tools/hako.py doctor' then 'python tools/hako.py build', followed by 'bash install-python-runtime.bash'."
+          fi
+          ;;
+        *)
+          if [[ "${MODE}" == "bootstrap" ]]; then
+            die "Unsupported Linux architecture for prebuilt runtime bundle: $(uname -m). Set HAKO_PDU_ENDPOINT_RUNTIME_URL/HAKO_PDU_ENDPOINT_ARCHIVE_BASENAME or use the manifest-driven source build."
+          fi
+          ;;
+      esac
     fi
     ;;
   Darwin)
-    if [[ -z "${ARCHIVE_BASENAME}" ]]; then
+    if [[ -z "${ARCHIVE_BASENAME}" && -z "${RUNTIME_URL}" ]]; then
       case "$(uname -m)" in
         arm64) ARCHIVE_BASENAME="hakoniwa-pdu-endpoint-macos-arm64-cp312.zip" ;;
         x86_64) ARCHIVE_BASENAME="hakoniwa-pdu-endpoint-macos-x86_64-cp312.zip" ;;
@@ -64,7 +84,11 @@ case "$(uname -s)" in
     ;;
 esac
 
-if [[ -z "${RUNTIME_URL}" ]]; then
+if [[ -z "${ARCHIVE_BASENAME}" && -n "${RUNTIME_URL}" ]]; then
+  ARCHIVE_BASENAME="${RUNTIME_URL##*/}"
+fi
+
+if [[ -z "${RUNTIME_URL}" && -n "${ARCHIVE_BASENAME}" ]]; then
   RUNTIME_URL="https://github.com/hakoniwalab/hakoniwa-pdu-endpoint/releases/download/${VERSION}/${ARCHIVE_BASENAME}"
 fi
 
@@ -75,6 +99,8 @@ install_python_packages() {
 }
 
 download_runtime_bundle() {
+  [[ -n "${ARCHIVE_BASENAME}" ]] || die "Runtime archive basename is empty"
+  [[ -n "${RUNTIME_URL}" ]] || die "Runtime URL is empty"
   local archive_path="${PREFIX_DIR}/${ARCHIVE_BASENAME}"
   mkdir -p "${PREFIX_DIR}"
   say "Downloading runtime bundle..."
@@ -87,7 +113,7 @@ download_runtime_bundle() {
 say "MODE=${MODE}"
 say "PYTHON_CMD=${PYTHON_CMD}"
 say "PREFIX_DIR=${PREFIX_DIR}"
-say "RUNTIME_URL=${RUNTIME_URL}"
+say "RUNTIME_URL=${RUNTIME_URL:-<none>}"
 
 case "${MODE}" in
   bootstrap)
@@ -106,5 +132,4 @@ say "Downloaded runtime bundle into: ${PREFIX_DIR}"
 say "Next step: overlay runtime files into the installed Python package:"
 say "  bash install-python-runtime.bash"
 say "If the target Python package directory is system-owned, run only that overlay step with sudo."
-
 say "Done."

--- a/python/README.ja.md
+++ b/python/README.ja.md
@@ -37,12 +37,16 @@ GitHub Releases から、自分の OS / CPU / Python ABI に対応した zip bun
 
 想定 asset 名:
 
-- Linux: `hakoniwa-pdu-endpoint-linux-x86_64-cp312.zip`
+- Linux:
+  - `hakoniwa-pdu-endpoint-linux-x86_64-cp312.zip`
+  - ARM64 / aarch64 は現在 prebuilt bundle 未提供（後述の source build を使用）
 - macOS:
   - `hakoniwa-pdu-endpoint-macos-x86_64-cp312.zip`
   - `hakoniwa-pdu-endpoint-macos-arm64-cp312.zip`
 - Windows:
   - `hakoniwa-pdu-endpoint-windows-x64-cp312.zip`
+
+`install-python.bash` の `bootstrap` モードは Linux の CPU architecture を確認します。prebuilt bundle が存在しない ARM64 / aarch64 では x86_64 bundle を誤って取得せず、manifest-driven source build へ誘導して終了します。
 
 zip を展開したディレクトリには次のものが入っています。
 
@@ -64,6 +68,66 @@ POSIX では installer を 2 段に分けています。
   - installed package directory への runtime overlay
 
 copy 権限だけが必要な環境では、後者だけ `sudo` 実行できます。
+
+### 2.1 Linux ARM64 / Raspberry Pi は manifest-driven source build を使う
+
+Raspberry Pi などの Linux ARM64 / aarch64 環境では、別系統のビルド手順を使うのではなく、リポジトリ共通の `hakoniwa-build.yaml` と `tools/hako.py` を使います。
+
+まず共通の native / Python build 前提を用意します。Ubuntu 24.04 の例:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y build-essential cmake libboost-dev python3-dev
+python3 -m pip install --upgrade pip setuptools cffi
+```
+
+Zenoh を使う場合は `zenoh-c` のビルドに Rust toolchain (`cargo`, `rustc`) が必要です。Rust を導入した後、`cargo` と `rustc` が `PATH` 上にあることを確認してください。
+
+```bash
+cargo --version
+rustc --version
+```
+
+`hakoniwa-build.yaml` では必要な機能だけを有効にします。ROS 2 / `rmw_zenoh` と通信するだけなら Hakoniwa Core は不要です。
+
+```yaml
+bindings:
+  python: true
+
+features:
+  hakoniwa_core: false
+  zenoh: true
+  mqtt: false
+```
+
+SHM または Hakoniwa time source が必要な場合だけ `features.hakoniwa_core: true` にし、`paths.hakoniwa_core_root` または `HAKONIWA_CORE_ROOT` でインストール済み Hakoniwa Core を指定してください。ARM64 で Core の prebuilt package がない環境では `hakoniwa-core-pro` をソースから用意します。
+
+設定確認とビルドは全 OS 共通です。
+
+```bash
+python3 tools/hako.py doctor
+python3 tools/hako.py configure --dry-run
+python3 tools/hako.py build
+python3 tools/hako.py test
+```
+
+checkout 上の build 結果をそのまま使う場合は、たとえば次のように Python と native library の場所を明示します。
+
+```bash
+export PYTHONPATH="$(pwd)/python:$(pwd)/build/python:${PYTHONPATH:-}"
+export HAKO_PDU_ENDPOINT_SHARED_LIB="$(pwd)/build/src/libhakoniwa_pdu_endpoint.so"
+export HAKO_PDU_ENDPOINT_LIB_DIR="$(pwd)/build/src"
+```
+
+Hakoniwa Core を有効にした場合は、Core の shared library も dynamic loader から見える必要があります。
+
+```bash
+export LD_LIBRARY_PATH="/usr/local/hakoniwa/lib:${LD_LIBRARY_PATH:-}"
+```
+
+Zenoh を有効にした pdu-endpoint は vendored `zenoh-c` を static link するため、pdu-endpoint の `build/_deps/...` 配下にある `libzenohc.so` を `LD_LIBRARY_PATH` へ追加する必要はありません。ROS 2 Jazzy の `rmw_zenoh_cpp` が独自の `libzenohc.so` を提供している環境でも、pdu-endpoint 用の Zenoh runtime を loader の検索順で切り替える構成にはしません。
+
+`venv --system-site-packages`、`rclpy`、`colcon`、ROS 2 package の実行環境などは pdu-endpoint の native/Python runtime ではなく `hakoniwa-pdu-ros` 側の integration concern です。ROS 2 bridge を構築する場合は `hakoniwa-pdu-ros` のセットアップ手順と合わせて確認してください。
 
 ## 3. 環境変数を設定する
 
@@ -193,6 +257,18 @@ pip show hakoniwa-pdu-endpoint
 
 `HAKO_PDU_ENDPOINT_SHARED_LIB` と `HAKO_PDU_ENDPOINT_LIB_DIR` を設定してください。
 
+### Linux ARM64 で `install-python.bash` が停止する
+
+prebuilt ARM64 bundle は未提供です。`bootstrap` の URL を x86_64 bundle に置き換えず、2.1 の manifest-driven source build を使用してください。
+
+### Zenoh 有効化時に Rust toolchain が見つからない
+
+`cargo` と `rustc` が `PATH` 上にあることを確認してください。Zenoh 有効時は CMake configure の段階で不足を明示的に検出します。
+
+### ROS 2 と同時利用すると `libzenohc.so` が競合する
+
+現在の source build は vendored `zenoh-c` を pdu-endpoint に static link します。pdu-endpoint 用 `libzenohc.so` を `LD_LIBRARY_PATH` の先頭へ追加する回避策は不要です。古い build artifact が残っている場合は build directory を作り直してください。
+
 ### Windows で `py` コマンドが無い
 
 `py` の代わりに `python` を使ってください。
@@ -208,3 +284,5 @@ python -m pip install --upgrade setuptools wheel cffi
 - PyPI: `pip install hakoniwa-pdu-endpoint`
 - GitHub Releases: native binary 配布元
 - Repository README: 開発者向けの build / test / release 手順
+- Build Architecture: `docs/build-architecture.md`
+- ROS 2 bridge: `hakoniwa-pdu-ros`

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,6 +16,14 @@ project(hakoniwa_pdu_endpoint LANGUAGES CXX)
 if(HAKO_PDU_ENDPOINT_ENABLE_ZENOH)
   include(FetchContent)
 
+  find_program(HAKO_PDU_ENDPOINT_CARGO_EXECUTABLE cargo)
+  find_program(HAKO_PDU_ENDPOINT_RUSTC_EXECUTABLE rustc)
+  if(NOT HAKO_PDU_ENDPOINT_CARGO_EXECUTABLE OR NOT HAKO_PDU_ENDPOINT_RUSTC_EXECUTABLE)
+    message(FATAL_ERROR
+      "Zenoh support requires a Rust toolchain (cargo and rustc) on PATH. "
+      "Install Rust with rustup and ensure $HOME/.cargo/bin is available before configuring.")
+  endif()
+
   file(STRINGS "${CMAKE_CURRENT_LIST_DIR}/../ZENOH_VERSION.txt" HAKO_ZENOH_C_VERSION_RAW
        LIMIT_COUNT 1 REGEX "^[^# \t].*")
   if(NOT HAKO_ZENOH_C_VERSION_RAW)
@@ -195,7 +203,13 @@ else()
 endif()
 
 if(HAKO_PDU_ENDPOINT_ENABLE_ZENOH)
-  if(TARGET zenohc::lib)
+  # Keep the vendored zenoh-c implementation inside pdu-endpoint even when
+  # hakoniwa_pdu_endpoint itself is shared. This avoids a runtime dependency
+  # on libzenohc.so, which can otherwise be resolved to ROS 2's rmw_zenoh
+  # vendor copy when both runtimes are loaded in the same process.
+  if(TARGET zenohc::static)
+    target_link_libraries(hakoniwa_pdu_endpoint PUBLIC zenohc::static)
+  elseif(TARGET zenohc::lib)
     target_link_libraries(hakoniwa_pdu_endpoint PUBLIC zenohc::lib)
   elseif(TARGET zenohc)
     target_link_libraries(hakoniwa_pdu_endpoint PUBLIC zenohc)
@@ -258,8 +272,8 @@ if(HAKO_PDU_ENDPOINT_ENABLE_HAKONIWA_CORE)
     target_include_directories(hakoniwa_pdu_endpoint PUBLIC ${HAKONIWA_INCLUDE_DIRS})
 
     set(HAKONIWA_LIB_DIRS "${HAKO_HAKONIWA_CORE_ROOT}/lib")
-    if(UNIX AND NOT APPLE)
-      list(APPEND HAKONIWA_LIB_DIRS /usr/lib/x86_64-linux-gnu)
+    if(UNIX AND NOT APPLE AND CMAKE_LIBRARY_ARCHITECTURE)
+      list(APPEND HAKONIWA_LIB_DIRS "/usr/lib/${CMAKE_LIBRARY_ARCHITECTURE}")
     endif()
 
     set(HAKONIWA_LINK_LIBS "")

--- a/tools/hako.py
+++ b/tools/hako.py
@@ -343,6 +343,14 @@ def doctor(ctx: BuildContext) -> tuple[list[str], list[str]]:
     warnings: list[str] = []
     if not shutil.which("cmake"):
         errors.append("CMake was not found on PATH")
+    if ctx.cfg["features"]["zenoh"]:
+        missing_rust_tools = [tool for tool in ("cargo", "rustc") if not shutil.which(tool)]
+        if missing_rust_tools:
+            errors.append(
+                "Zenoh support requires a Rust toolchain on PATH; missing: "
+                + ", ".join(missing_rust_tools)
+                + " (install Rust with rustup and ensure $HOME/.cargo/bin is on PATH)"
+            )
     if ctx.cfg["bindings"]["python"]:
         if importlib.util.find_spec("cffi") is None:
             errors.append("Python package 'cffi' is missing (install with: python -m pip install cffi)")

--- a/tools/test_hako.py
+++ b/tools/test_hako.py
@@ -3,6 +3,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 MODULE_PATH = Path(__file__).with_name("hako.py")
 spec = importlib.util.spec_from_file_location("hako_build_tool", MODULE_PATH)
@@ -58,6 +59,54 @@ class ConfigTests(unittest.TestCase):
             'version: 1 # comment\nbuild:\n  dir: "build#local" # another comment\n'
         )
         self.assertEqual(cfg["build"]["dir"], "build#local")
+
+    def test_aarch64_normalizes_to_arm64(self):
+        with patch.object(hako.sys, "platform", "linux"), patch.object(
+            hako.platform, "machine", return_value="aarch64"
+        ):
+            self.assertEqual(hako._host_platform(), ("linux", "arm64"))
+
+
+class DoctorTests(unittest.TestCase):
+    def make_context(self, *, zenoh: bool):
+        cfg = hako.resolve_config(
+            {
+                "version": 1,
+                "bindings": {"python": False},
+                "features": {"zenoh": zenoh},
+            }
+        )
+        return hako.BuildContext(
+            repo_root=Path("."),
+            manifest_path=Path("hakoniwa-build.yaml"),
+            cfg=cfg,
+            platform_name="linux",
+            arch="arm64",
+            build_dir=Path("build"),
+            vcpkg_root=None,
+            core_root=None,
+            vcpkg_triplet="",
+            child_env={},
+        )
+
+    def test_zenoh_requires_rust_toolchain(self):
+        ctx = self.make_context(zenoh=True)
+
+        def fake_which(command: str):
+            if command in {"cargo", "rustc"}:
+                return None
+            return f"/usr/bin/{command}"
+
+        with patch.object(hako.shutil, "which", side_effect=fake_which):
+            errors, _warnings = hako.doctor(ctx)
+
+        self.assertTrue(any("missing: cargo, rustc" in error for error in errors))
+
+    def test_rust_toolchain_not_required_without_zenoh(self):
+        ctx = self.make_context(zenoh=False)
+        with patch.object(hako.shutil, "which", return_value="/usr/bin/cmake"):
+            errors, _warnings = hako.doctor(ctx)
+        self.assertEqual(errors, [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Extend the manifest-driven build architecture introduced in #40 with the Raspberry Pi / ARM64 / ROS 2 / Zenoh findings reported by @kuboaki in #36.

This keeps ARM64 as the same build model rather than introducing a Raspberry Pi-specific build path.

## Changes

- make `install-python.bash` detect Linux architecture instead of assuming x86_64
  - x86_64 keeps using the prebuilt runtime bundle
  - ARM64/aarch64 fails early with a clear source-build route while no prebuilt bundle exists
  - explicit custom runtime URL/archive overrides remain available
- extend `tools/hako.py doctor` so `features.zenoh: true` requires `cargo` and `rustc`
- add the same Rust preflight at CMake configure time for direct-CMake users
- prefer vendored `zenohc::static` when Zenoh is enabled
  - this removes the normal runtime dependency on a separately resolved `libzenohc.so`
  - it is intended to avoid collisions with the `libzenohc.so` shipped by ROS 2 `rmw_zenoh_cpp`
- replace the hard-coded `/usr/lib/x86_64-linux-gnu` Hakoniwa Core fallback with `/usr/lib/${CMAKE_LIBRARY_ARCHITECTURE}`
- document the Linux ARM64/Raspberry Pi flow in `python/README.ja.md`
  - use `hakoniwa-build.yaml` + `tools/hako.py`
  - keep Hakoniwa Core disabled unless SHM/time-source support is actually required
  - keep ROS 2 venv/colcon/rclpy setup as a `hakoniwa-pdu-ros` integration concern
  - no longer require an `LD_LIBRARY_PATH` workaround for a pdu-endpoint-owned `libzenohc.so`
- record the ARM64 and Zenoh dependency decisions in `docs/build-architecture.md`
- add a dedicated Linux CI job for the shared endpoint + Zenoh combination and assert that `libzenohc.so` is not a dynamic dependency

## Root cause

Two previously implicit assumptions surfaced on the Raspberry Pi setup from #36:

1. Linux bootstrap/install paths still contained x86_64-specific assumptions.
2. Python/cffi requires a shared `hakoniwa_pdu_endpoint`, and `zenohc::lib` follows the parent `BUILD_SHARED_LIBS` value. With a shared parent this selected shared zenoh-c, leaving `libhakoniwa_pdu_endpoint.so` dependent on `libzenohc.so`. In a ROS 2 Jazzy process, the loader could then resolve that dependency to the `rmw_zenoh_cpp` vendor copy instead of the version used to build pdu-endpoint.

The build now treats vendored zenoh-c as an implementation dependency of pdu-endpoint and prefers its static target.

## Validation

- `tools/test_hako.py` covers `aarch64 -> arm64` normalization
- doctor coverage verifies that Zenoh requires `cargo` and `rustc`, while non-Zenoh manifests do not
- the manifest test matrix runs on Ubuntu, macOS, and Windows
- `linux-zenoh-shared` builds `BUILD_SHARED_LIBS=ON` + Zenoh and checks the resulting ELF does not declare `libzenohc.so` as `NEEDED`
- existing native and Python smoke jobs remain in place

@kuboaki, if you have time, we'd especially appreciate verification on the Raspberry Pi / Ubuntu 24.04 / ROS 2 Jazzy environment from #36, including the previous `libzenohc.so` collision / stack-smashing case.

Closes #36