### PR TITLE
test: characterize existing config JSON round trips

### DIFF
--- a/python/test/test_config_json_roundtrip.py
+++ b/python/test/test_config_json_roundtrip.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+# Representative existing configuration files. These files are the compatibility
+# boundary for Issue #35: loading and re-serializing them must preserve semantic
+# JSON equality even when formatting changes.
+REPRESENTATIVE_CONFIGS = [
+    Path("config/sample/endpoint_tcp_server.json"),
+    Path("config/sample/cache/buffer.json"),
+    Path("config/sample/comm/storage_latest_out_comm.json"),
+    Path("config/sample/endpoint_container.json"),
+    Path("test/test_endpoint_buffer.json"),
+    Path("test/test_endpoint_queue.json"),
+]
+
+
+def load_json(path: Path):
+    with path.open("r", encoding="utf-8") as fp:
+        return json.load(fp)
+
+
+class ConfigJsonRoundTripTest(unittest.TestCase):
+    def test_representative_configs_round_trip_semantically(self):
+        with tempfile.TemporaryDirectory(prefix="hako-pdu-config-roundtrip-") as temp_dir:
+            temp_root = Path(temp_dir)
+
+            for relative_path in REPRESENTATIVE_CONFIGS:
+                with self.subTest(config=str(relative_path)):
+                    source_path = PROJECT_ROOT / relative_path
+                    self.assertTrue(source_path.is_file(), f"missing fixture: {relative_path}")
+
+                    before = load_json(source_path)
+                    output_path = temp_root / relative_path.name
+                    output_path.write_text(
+                        json.dumps(before, indent=2, ensure_ascii=False) + "\n",
+                        encoding="utf-8",
+                    )
+                    after = load_json(output_path)
+
+                    self.assertEqual(before, after)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test-python.bash
+++ b/test-python.bash
@@ -6,6 +6,7 @@ BUILD_FIRST=${BUILD_FIRST:-ON}
 PYTHON_CMD=${PYTHON_CMD:-python3}
 
 PYTHON_TESTS=(
+  "${PROJECT_ROOT}/python/test/test_config_json_roundtrip.py"
   "${PROJECT_ROOT}/python/test/test_c_endpoint_smoke.py"
   "${PROJECT_ROOT}/python/test/test_c_endpoint_callback_smoke.py"
   "${PROJECT_ROOT}/python/test/test_c_endpoint_ros_style_smoke.py"


### PR DESCRIPTION
## Closed by design refinement

This PR was opened as an early characterization/round-trip test, but the #35 design discussion has since clarified that the configuration API contract must be specified before meaningful API-level tests can be written.

The new order is:

1. lifecycle/default ownership specification (#42, merged);
2. define the concrete default-config API contract, including provider selection, JSON-text options overlay, unsupported-option behavior, persistence, and language-neutral C ABI considerations;
3. add tests against that API contract;
4. implement the common layer and first representative provider.

The pure `json.load -> dump -> load` check in this PR does not exercise the intended endpoint/config API and would therefore freeze the wrong abstraction at this stage.

The useful regression intent from this PR will be reintroduced after the API specification is agreed, at the correct layer (including future C API/cffi coverage where appropriate).

Refs #35
Follows #42