### PR TITLE
docs: Add Default Configuration API specification

### DIFF
--- a/docs/configuration-api.md
+++ b/docs/configuration-api.md
@@ -4,22 +4,28 @@ This document specifies the Default Configuration API for `hakoniwa-pdu-endpoint
 
 ## 1. Overview
 
-The primary goal of this API is to simplify the programmatic creation of endpoint configurations. It allows users to generate a default configuration for a specific communication protocol, optionally customize it with partial settings, and persist the final, effective configuration as a JSON file for auditing and debugging.
+The primary goal of this API is to support **file-less runtime configuration**: endpoint configuration can be constructed in memory and consumed directly by the endpoint runtime without requiring a configuration file as an input.
 
-This API does not introduce a new configuration format but rather provides a more convenient way to construct configurations that conform to the existing JSON schema.
+A caller selects a supported communication provider, starts from its canonical default configuration, and optionally customizes only the required fields using a partial JSON object. The resulting effective configuration is then used directly for endpoint initialization.
+
+The effective configuration may also be persisted as JSON for **auditability, reproducibility, and debugging**. Persistence is optional and is not required for runtime execution.
+
+This API does not introduce a new configuration format. It provides a programmatic path for constructing configurations that conform to the existing JSON configuration structure and validation model.
 
 ## 2. Design Principles
 
+- **File-less Runtime Configuration**: Runtime execution must not require an intermediate configuration file. The effective configuration is kept in memory and consumed directly by endpoint initialization.
 - **Communication-Independent API**: The top-level API for creating configurations is independent of the underlying communication (`comm`) protocol. This ensures that future additions of `comm` providers will not require changes to the client-side API bindings (C++, C, Python, Godot, etc.).
 - **JSON-based Options**: Configuration options are passed as a simple JSON text string. This avoids the need for protocol-specific data structures in the C-ABI and other language bindings, preventing breaking changes when options are added or modified.
 - **Partial JSON Overlay**: Customizations are applied by overlaying a partial JSON object onto the default configuration. This reuses the existing, well-understood JSON structure and avoids introducing a new language for options.
 - **Explicit Failure**: The API is designed to fail explicitly for invalid inputs, such as malformed JSON or unsupported option keys. It will not silently ignore errors or fall back to default values for unrecognized options (e.g., misspelled keys).
+- **Optional Persistence**: Saving the effective configuration is a secondary operation for audit and reproduction purposes; it is not part of the mandatory runtime path.
 
 ## 3. API Contract
 
 ### Conceptual API
 
-The core of the API can be represented by a single conceptual function:
+The configuration creation API can be represented by the following conceptual function:
 
 ```cpp
 // Conceptual C++
@@ -32,9 +38,33 @@ EffectiveConfiguration create_default(
 - `provider_name`: A string identifying the configuration provider, typically corresponding to a `comm` type (e.g., `"tcp"`, `"udp"`).
 - `options_json`: An optional JSON string representing the partial configuration to overlay on the default.
 
+The returned `EffectiveConfiguration` is an in-memory runtime object. The endpoint initialization path must be able to consume this object directly, without first serializing it to a file.
+
+Conceptually, the runtime path is:
+
+```text
+default configuration
+        +
+partial JSON options
+        |
+        v
+effective configuration (in memory)
+        |
+        v
+endpoint initialization / execution
+```
+
+Persistence is an optional side path:
+
+```text
+effective configuration
+        |
+        +--> save as JSON (audit / reproduction / debugging)
+```
+
 ### C-ABI Example
 
-The C-ABI will be designed to be stable and protocol-agnostic. A specific function signature will be finalized during implementation, but it will follow this principle:
+The C-ABI will be designed to be stable and protocol-agnostic. Specific endpoint-initialization signatures will be finalized during implementation, but they must preserve the following contract:
 
 ```c
 // Conceptual C-ABI
@@ -45,7 +75,12 @@ hako_pdu_config_t* hako_pdu_config_create_default(
     hako_pdu_error_t* err
 );
 
-// Persists the configuration to a file.
+// The endpoint runtime consumes the in-memory configuration directly.
+// The exact endpoint initialization API is implementation-specific and
+// will be finalized during the implementation phase.
+
+// Optionally persists the effective configuration for auditing,
+// reproducibility, or debugging.
 hako_pdu_error_t hako_pdu_config_save(
     hako_pdu_config_t* config,
     const char* path
@@ -55,16 +90,37 @@ hako_pdu_error_t hako_pdu_config_save(
 void hako_pdu_config_destroy(hako_pdu_config_t* config);
 ```
 
+The important compatibility contract is that language bindings operate on a stable configuration handle plus JSON text, rather than protocol-specific option structures.
+
 ## 4. Configuration Providers
 
-The responsibility for providing default configurations lies with the components that own the configuration semantics.
+The responsibility for defining default values and supported override keys belongs to the component that owns the corresponding configuration semantics.
 
-- **`comm` Providers**: Each communication implementation (e.g., TCP, UDP, Zenoh) is responsible for its own optional "default provider." This provider defines:
-    - The canonical default configuration.
-    - The set of overridable option keys.
-    - The logic for merging (overlaying) user-provided options.
-- **Common Layer**: The common configuration layer does not know the specifics of protocol defaults.
-- **Unsupported `comm`s**: If a `comm` implementation does not have a default provider, attempting to generate a default configuration for it will result in an explicit error. All configuration for such `comm`s must be provided manually.
+Conceptually, a `comm` provider defines:
+
+- The canonical default configuration.
+- The set of overridable option keys.
+- The logic for applying the partial JSON overlay.
+
+The common configuration layer remains independent of protocol-specific defaults.
+
+If a `comm` implementation does not support default configuration generation, attempting to create a default configuration for it results in an explicit unsupported-provider error. Such configurations must continue to be supplied through the existing manual configuration path.
+
+### Initial implementation note
+
+The provider abstraction is a **responsibility boundary**, not a requirement to introduce a general provider framework in the first implementation.
+
+The initial implementation may use a simple dispatch for the supported provider, for example:
+
+```cpp
+if (provider_name == "tcp") {
+    // create TCP defaults and apply supported overrides
+} else {
+    return UNSUPPORTED_PROVIDER;
+}
+```
+
+A more extensible registration or provider mechanism may be introduced later when multiple implementations justify it.
 
 ## 5. Options Overlay Mechanism
 
@@ -81,7 +137,9 @@ For example, to create a default TCP server configuration but override the port,
 }
 ```
 
-The provider will merge this onto its default TCP configuration.
+The supported provider merges this onto its canonical default configuration.
+
+Only explicitly supported keys may be overridden. Unknown or unsupported keys result in an error rather than being ignored.
 
 ## 6. Validation Strategy
 
@@ -89,52 +147,95 @@ Validation is performed in stages to avoid duplicating logic.
 
 ### Phase 1: Initial Checks (This API's Scope)
 
-The default provider will perform the following minimal checks:
-1.  **JSON Parsability**: Verify that `options_json` is a valid JSON string.
-2.  **JSON Type**: Verify that the parsed JSON is an object.
-3.  **Supported Keys**: Verify that all top-level and nested keys in the `options_json` are known and supported by the provider. An unknown key will result in an error.
+The default configuration creation path performs the following minimal checks:
 
-### Phase 2: Full Schema Validation (Future Scope)
+1. **JSON Parsability**: Verify that `options_json` is a valid JSON string.
+2. **JSON Type**: Verify that the parsed JSON is an object.
+3. **Supported Keys**: Verify that all top-level and nested keys in the `options_json` are known and supported by the selected provider. An unknown key results in an error.
 
-Detailed validation of values (e.g., type, enum, range, semantic rules) is **out of scope** for the default provider itself. This responsibility remains with the existing runtime configuration loader, which already uses a JSON Schema validator. The effective configuration generated by this API will be passed to that existing validation layer before execution.
+This phase intentionally implements only the minimum validation required to safely construct the effective configuration.
+
+### Phase 2: Full Schema Validation
+
+Detailed validation of values (e.g., type, enum, range, semantic rules) remains the responsibility of the existing runtime configuration validation layer, which already uses JSON Schema.
+
+The effective configuration generated by this API must pass through the same authoritative validation rules before runtime execution as file-based configuration.
 
 This separates concerns:
-- **This API**: Constructs a configuration object.
-- **Future Work**: Use the existing JSON Schema validator as a common, authoritative validation layer for all configuration, whether from a file or from this API.
 
-## 7. Persistence
+- **This API**: Constructs an effective configuration in memory from defaults plus supported overrides.
+- **Existing validation layer**: Validates the complete effective configuration before use.
 
-The final, effective configuration can be saved to a set of JSON files. This serves as an auditable artifact.
+This avoids maintaining two independent validation rule sets.
 
-- The API will provide a function to save the configuration (e.g., `hako_pdu_config_save`).
-- The user can specify an output directory.
-- If no directory is specified, the files will be saved to the default runtime directory (`config/runtime/`), as defined in `configuration-lifecycle.md`.
+## 7. Runtime Consumption
 
-## 8. Initial Implementation Scope
+The effective configuration is primarily a runtime object, not a file-generation artifact.
 
-The first implementation will focus on establishing the core pattern:
-1.  **Common Configuration API**: The language-agnostic C-ABI and C++ implementation.
-2.  **Persistence**: The ability to save the effective configuration.
-3.  **A Representative `comm` Provider**: A default provider for **TCP** will be implemented as the first example.
+The endpoint initialization flow must accept the effective in-memory configuration directly. Serializing the configuration and reading it back from disk must not be required for normal execution.
 
-Default providers for other `comm` types (UDP, MQTT, Zenoh, etc.) will be added incrementally in separate pull requests.
+The exact integration point with the existing endpoint initialization API will be finalized during implementation, but the following behavior is required:
 
-## 9. Testing Strategy
+1. Create the default configuration for a supported provider.
+2. Apply the caller's supported JSON overrides.
+3. Validate the resulting effective configuration using the existing validation rules.
+4. Initialize the endpoint directly from the resulting in-memory configuration.
 
-While tests will be implemented in a subsequent pull request, the strategy is defined here:
+## 8. Persistence and Auditability
 
-- Tests will target the **API contract**, not the internal implementation details of JSON serialization (e.g., `json.load`/`json.dump`).
-- The goal is to verify the semantics of the configuration API, ensuring that creating, modifying, and persisting a configuration behaves as expected.
-- This approach ensures that the tests are durable and can be used to validate bindings in other languages (Python, C#, Godot) against the same core behavior.
+The final effective configuration can optionally be saved as JSON. This is a secondary capability intended for operational visibility rather than runtime dependency.
 
-## 10. Out of Scope
+Typical uses include:
 
-The following items are explicitly **not** part of this API specification and its initial implementation:
+- Recording the exact configuration used for a run.
+- Reproducing a previously executed setup.
+- Comparing generated configuration during debugging.
+- Retaining an auditable runtime artifact.
 
-- A full implementation of the API.
-- The addition of unit or integration tests.
+The API will provide a save operation such as `hako_pdu_config_save`.
+
+The caller may specify an output path or directory. If the implementation supports a default output location, it should remain consistent with the runtime configuration conventions defined in `configuration-lifecycle.md` (for example, `config/runtime/`).
+
+Failure to persist an optional audit copy is distinct from the ability to construct and use the configuration in memory; normal runtime execution does not require a saved file unless explicitly requested by the caller's workflow.
+
+## 9. Initial Implementation Scope
+
+The first implementation will focus on the minimum useful end-to-end path:
+
+1. **Common Configuration API**: Language-agnostic C-ABI and C++ representation for an in-memory effective configuration.
+2. **TCP Defaults**: Canonical default configuration for TCP as the representative first provider.
+3. **Minimal JSON Overlay**: Support only the initial documented set of TCP override keys.
+4. **Explicit Unsupported-input Errors**: Reject malformed JSON, unknown keys, and unsupported providers.
+5. **Runtime Consumption**: Allow endpoint initialization to consume the effective configuration directly from memory.
+6. **Optional Persistence**: Allow the effective configuration to be saved as JSON for auditing, reproduction, and debugging.
+
+Default support for other `comm` types (UDP, MQTT, Zenoh, etc.) will be added incrementally in separate pull requests.
+
+The initial implementation should prefer simple, explicit code over introducing a generalized provider framework before multiple providers require it.
+
+## 10. Testing Strategy
+
+Tests will target the **API contract**, not the internal implementation details of JSON serialization.
+
+The core behavior to verify is:
+
+- Default configuration creation succeeds for the supported provider.
+- Supported partial overrides are applied correctly.
+- Malformed JSON and unsupported keys fail explicitly.
+- Unsupported providers fail explicitly.
+- The resulting configuration can be consumed directly by endpoint initialization without a configuration file.
+- Saving and reloading the audit artifact reproduces the same effective configuration semantics.
+
+This approach keeps the tests durable and allows bindings in other languages (Python, C#, Godot, etc.) to be validated against the same core behavior.
+
+## 11. Out of Scope
+
+The following items are explicitly **not** part of the initial implementation:
+
 - Default providers for all `comm` types.
+- A generalized provider registration framework.
 - A new configuration file format or schema.
 - A new, generic configuration validator.
-- The integration of the JSON Schema validator into the default creation flow.
+- Duplicating JSON Schema validation rules inside the default configuration creator.
+- Broad support for every possible TCP configuration field in the first version.
 - The implementation of C-bindings for cffi (Python), C#, or Godot.

--- a/docs/configuration-api.md
+++ b/docs/configuration-api.md
@@ -1,0 +1,140 @@
+# Default Configuration API Specification
+
+This document specifies the Default Configuration API for `hakoniwa-pdu-endpoint`, as proposed in [Issue #35](https://github.com/hakoniwalab/hakoniwa-pdu-endpoint/issues/35) and building upon the design principles outlined in `docs/configuration-lifecycle.md`.
+
+## 1. Overview
+
+The primary goal of this API is to simplify the programmatic creation of endpoint configurations. It allows users to generate a default configuration for a specific communication protocol, optionally customize it with partial settings, and persist the final, effective configuration as a JSON file for auditing and debugging.
+
+This API does not introduce a new configuration format but rather provides a more convenient way to construct configurations that conform to the existing JSON schema.
+
+## 2. Design Principles
+
+- **Communication-Independent API**: The top-level API for creating configurations is independent of the underlying communication (`comm`) protocol. This ensures that future additions of `comm` providers will not require changes to the client-side API bindings (C++, C, Python, Godot, etc.).
+- **JSON-based Options**: Configuration options are passed as a simple JSON text string. This avoids the need for protocol-specific data structures in the C-ABI and other language bindings, preventing breaking changes when options are added or modified.
+- **Partial JSON Overlay**: Customizations are applied by overlaying a partial JSON object onto the default configuration. This reuses the existing, well-understood JSON structure and avoids introducing a new language for options.
+- **Explicit Failure**: The API is designed to fail explicitly for invalid inputs, such as malformed JSON or unsupported option keys. It will not silently ignore errors or fall back to default values for unrecognized options (e.g., misspelled keys).
+
+## 3. API Contract
+
+### Conceptual API
+
+The core of the API can be represented by a single conceptual function:
+
+```cpp
+// Conceptual C++
+EffectiveConfiguration create_default(
+    const std::string& provider_name,
+    const std::string& options_json = "{}"
+);
+```
+
+- `provider_name`: A string identifying the configuration provider, typically corresponding to a `comm` type (e.g., `"tcp"`, `"udp"`).
+- `options_json`: An optional JSON string representing the partial configuration to overlay on the default.
+
+### C-ABI Example
+
+The C-ABI will be designed to be stable and protocol-agnostic. A specific function signature will be finalized during implementation, but it will follow this principle:
+
+```c
+// Conceptual C-ABI
+// The returned handle represents the in-memory configuration object.
+hako_pdu_config_t* hako_pdu_config_create_default(
+    const char *provider_name,
+    const char *options_json,
+    hako_pdu_error_t* err
+);
+
+// Persists the configuration to a file.
+hako_pdu_error_t hako_pdu_config_save(
+    hako_pdu_config_t* config,
+    const char* path
+);
+
+// Frees the in-memory configuration object.
+void hako_pdu_config_destroy(hako_pdu_config_t* config);
+```
+
+## 4. Configuration Providers
+
+The responsibility for providing default configurations lies with the components that own the configuration semantics.
+
+- **`comm` Providers**: Each communication implementation (e.g., TCP, UDP, Zenoh) is responsible for its own optional "default provider." This provider defines:
+    - The canonical default configuration.
+    - The set of overridable option keys.
+    - The logic for merging (overlaying) user-provided options.
+- **Common Layer**: The common configuration layer does not know the specifics of protocol defaults.
+- **Unsupported `comm`s**: If a `comm` implementation does not have a default provider, attempting to generate a default configuration for it will result in an explicit error. All configuration for such `comm`s must be provided manually.
+
+## 5. Options Overlay Mechanism
+
+Options are applied as a partial JSON overlay. The structure of the `options_json` must mirror the structure of the full JSON configuration file for the corresponding component.
+
+For example, to create a default TCP server configuration but override the port, the `options_json` would be:
+
+```json
+{
+  "role": "server",
+  "local": {
+    "port": 55000
+  }
+}
+```
+
+The provider will merge this onto its default TCP configuration.
+
+## 6. Validation Strategy
+
+Validation is performed in stages to avoid duplicating logic.
+
+### Phase 1: Initial Checks (This API's Scope)
+
+The default provider will perform the following minimal checks:
+1.  **JSON Parsability**: Verify that `options_json` is a valid JSON string.
+2.  **JSON Type**: Verify that the parsed JSON is an object.
+3.  **Supported Keys**: Verify that all top-level and nested keys in the `options_json` are known and supported by the provider. An unknown key will result in an error.
+
+### Phase 2: Full Schema Validation (Future Scope)
+
+Detailed validation of values (e.g., type, enum, range, semantic rules) is **out of scope** for the default provider itself. This responsibility remains with the existing runtime configuration loader, which already uses a JSON Schema validator. The effective configuration generated by this API will be passed to that existing validation layer before execution.
+
+This separates concerns:
+- **This API**: Constructs a configuration object.
+- **Future Work**: Use the existing JSON Schema validator as a common, authoritative validation layer for all configuration, whether from a file or from this API.
+
+## 7. Persistence
+
+The final, effective configuration can be saved to a set of JSON files. This serves as an auditable artifact.
+
+- The API will provide a function to save the configuration (e.g., `hako_pdu_config_save`).
+- The user can specify an output directory.
+- If no directory is specified, the files will be saved to the default runtime directory (`config/runtime/`), as defined in `configuration-lifecycle.md`.
+
+## 8. Initial Implementation Scope
+
+The first implementation will focus on establishing the core pattern:
+1.  **Common Configuration API**: The language-agnostic C-ABI and C++ implementation.
+2.  **Persistence**: The ability to save the effective configuration.
+3.  **A Representative `comm` Provider**: A default provider for **TCP** will be implemented as the first example.
+
+Default providers for other `comm` types (UDP, MQTT, Zenoh, etc.) will be added incrementally in separate pull requests.
+
+## 9. Testing Strategy
+
+While tests will be implemented in a subsequent pull request, the strategy is defined here:
+
+- Tests will target the **API contract**, not the internal implementation details of JSON serialization (e.g., `json.load`/`json.dump`).
+- The goal is to verify the semantics of the configuration API, ensuring that creating, modifying, and persisting a configuration behaves as expected.
+- This approach ensures that the tests are durable and can be used to validate bindings in other languages (Python, C#, Godot) against the same core behavior.
+
+## 10. Out of Scope
+
+The following items are explicitly **not** part of this API specification and its initial implementation:
+
+- A full implementation of the API.
+- The addition of unit or integration tests.
+- Default providers for all `comm` types.
+- A new configuration file format or schema.
+- A new, generic configuration validator.
+- The integration of the JSON Schema validator into the default creation flow.
+- The implementation of C-bindings for cffi (Python), C#, or Godot.


### PR DESCRIPTION
This document specifies the Default Configuration API, which allows for the programmatic creation and customization of endpoint configurations. It is based on the principles outlined in configuration-lifecycle.md.

This fulfills the specification phase for Issue #35 and follows the design of #42.

# 📦 What does this PR do?

(Please describe what this PR implements, changes, or fixes.)

## ✅ Checklist

- [ ] Code builds and passes all tests
- [ ] Documentation updated (if needed)
- [ ] Linter passes (if applicable)

## 🔗 Related Issue

Closes #

## 📸 Screenshots / Logs (if needed)

(N/A or attach)
