### PR TITLE
feat: add typed cache configuration model

### DIFF
--- a/include/hakoniwa/pdu/cache/cache_config.hpp
+++ b/include/hakoniwa/pdu/cache/cache_config.hpp
@@ -1,0 +1,65 @@
+#pragma once
+
+#include "hakoniwa/pdu/endpoint_types.hpp"
+
+#include <cstddef>
+#include <string>
+
+namespace hakoniwa {
+namespace pdu {
+
+enum class CacheMode {
+    Latest,
+    Queue,
+};
+
+struct CacheConfig {
+    std::string name;
+    CacheMode mode = CacheMode::Latest;
+    std::size_t depth = 1;
+};
+
+inline constexpr std::size_t HAKO_PDU_CACHE_NAME_MAX_LENGTH = 256;
+inline constexpr std::size_t HAKO_PDU_CACHE_QUEUE_DEPTH_MIN = 1;
+inline constexpr std::size_t HAKO_PDU_CACHE_QUEUE_DEPTH_MAX = 1024;
+
+inline HakoPduErrorType validate_cache_config(const CacheConfig& config) noexcept
+{
+    if (config.name.empty() || config.name.size() > HAKO_PDU_CACHE_NAME_MAX_LENGTH) {
+        return HAKO_PDU_ERR_INVALID_CONFIG;
+    }
+
+    switch (config.mode) {
+    case CacheMode::Latest:
+        return HAKO_PDU_ERR_OK;
+    case CacheMode::Queue:
+        if (config.depth < HAKO_PDU_CACHE_QUEUE_DEPTH_MIN ||
+            config.depth > HAKO_PDU_CACHE_QUEUE_DEPTH_MAX) {
+            return HAKO_PDU_ERR_INVALID_CONFIG;
+        }
+        return HAKO_PDU_ERR_OK;
+    }
+
+    return HAKO_PDU_ERR_INVALID_CONFIG;
+}
+
+inline CacheConfig make_latest_cache(std::string name)
+{
+    return CacheConfig{
+        .name = std::move(name),
+        .mode = CacheMode::Latest,
+        .depth = 1,
+    };
+}
+
+inline CacheConfig make_queue_cache(std::string name, std::size_t depth)
+{
+    return CacheConfig{
+        .name = std::move(name),
+        .mode = CacheMode::Queue,
+        .depth = depth,
+    };
+}
+
+} // namespace pdu
+} // namespace hakoniwa

--- a/include/hakoniwa/pdu/cache/cache_config.hpp
+++ b/include/hakoniwa/pdu/cache/cache_config.hpp
@@ -4,6 +4,7 @@
 
 #include <cstddef>
 #include <string>
+#include <utility>
 
 namespace hakoniwa {
 namespace pdu {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -32,5 +32,17 @@ endif()
 
 add_test(NAME endpoint_test COMMAND endpoint_test)
 
+add_executable(cache_config_test
+  cache_config_test.cpp
+)
+
+target_link_libraries(cache_config_test
+  PRIVATE
+    hakoniwa_pdu_endpoint
+    GTest::gtest_main
+)
+
+add_test(NAME cache_config_test COMMAND cache_config_test)
+
 # Set the working directory to the project root so tests can find the config files
 set_tests_properties(endpoint_test PROPERTIES WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}")

--- a/test/cache_config_test.cpp
+++ b/test/cache_config_test.cpp
@@ -1,0 +1,47 @@
+#include <gtest/gtest.h>
+
+#include "hakoniwa/pdu/cache/cache_config.hpp"
+
+#include <string>
+
+namespace {
+
+using hakoniwa::pdu::CacheMode;
+using hakoniwa::pdu::make_latest_cache;
+using hakoniwa::pdu::make_queue_cache;
+using hakoniwa::pdu::validate_cache_config;
+
+TEST(CacheConfigTest, LatestFactoryCreatesValidConfig)
+{
+    const auto config = make_latest_cache("vehicle_state");
+
+    EXPECT_EQ(config.name, "vehicle_state");
+    EXPECT_EQ(config.mode, CacheMode::Latest);
+    EXPECT_EQ(validate_cache_config(config), HAKO_PDU_ERR_OK);
+}
+
+TEST(CacheConfigTest, QueueFactoryCreatesValidConfig)
+{
+    const auto config = make_queue_cache("events", 16);
+
+    EXPECT_EQ(config.name, "events");
+    EXPECT_EQ(config.mode, CacheMode::Queue);
+    EXPECT_EQ(config.depth, 16U);
+    EXPECT_EQ(validate_cache_config(config), HAKO_PDU_ERR_OK);
+}
+
+TEST(CacheConfigTest, RejectsInvalidName)
+{
+    EXPECT_EQ(validate_cache_config(make_latest_cache("")), HAKO_PDU_ERR_INVALID_CONFIG);
+    EXPECT_EQ(
+        validate_cache_config(make_latest_cache(std::string(257, 'x'))),
+        HAKO_PDU_ERR_INVALID_CONFIG);
+}
+
+TEST(CacheConfigTest, RejectsQueueDepthOutsideSchemaRange)
+{
+    EXPECT_EQ(validate_cache_config(make_queue_cache("events", 0)), HAKO_PDU_ERR_INVALID_CONFIG);
+    EXPECT_EQ(validate_cache_config(make_queue_cache("events", 1025)), HAKO_PDU_ERR_INVALID_CONFIG);
+}
+
+} // namespace


### PR DESCRIPTION
## Summary

Implements Step 1 of the typed cache configuration API defined in `docs/cache-configuration-api.md`.

- add `CacheMode` and `CacheConfig`
- add small factories for `latest` and `queue`
- validate the existing schema constraints (`name`: 1-256, queue `depth`: 1-1024)
- add focused unit tests

## Scope

This PR is intentionally self-contained.

It does **not**:
- change `PduCache::open(config_path)`
- connect the typed config to Endpoint initialization
- change comm configuration
- add JSON serialization/persistence
- alter existing runtime behavior

Those steps can follow in separate PRs after this representation is accepted.
