### PR TITLE
refactor: configure cache runtime from CacheConfig

### DIFF
--- a/include/hakoniwa/pdu/cache/cache.hpp
+++ b/include/hakoniwa/pdu/cache/cache.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "hakoniwa/pdu/cache/cache_config.hpp"
 #include "hakoniwa/pdu/endpoint_types.hpp"
 #include <cstddef>
 #include <cstdint>
@@ -16,13 +17,13 @@ class PduCache
 public:
     PduCache() = default;
     virtual ~PduCache() = default;
-    // コピー・ムーブ禁止（ポリモーフィックな基底クラス）
     PduCache(const PduCache&) = delete;
     PduCache(PduCache&&) = delete;
     PduCache& operator=(const PduCache&) = delete;
     PduCache& operator=(PduCache&&) = delete;
 
     virtual HakoPduErrorType open(const std::string& config_path) = 0;
+    virtual HakoPduErrorType configure(const CacheConfig& config) noexcept = 0;
     virtual HakoPduErrorType close() noexcept = 0;
     virtual HakoPduErrorType start() noexcept = 0;
     virtual HakoPduErrorType stop() noexcept = 0;
@@ -45,7 +46,6 @@ public:
         (void)out;
         return HAKO_PDU_ERR_UNSUPPORTED;
     }
-
 };
 } // namespace pdu
 } // namespace hakoniwa

--- a/include/hakoniwa/pdu/cache/cache_buffer.hpp
+++ b/include/hakoniwa/pdu/cache/cache_buffer.hpp
@@ -2,6 +2,7 @@
 
 #include "hakoniwa/pdu/cache/cache.hpp"
 #include "hakoniwa/pdu/cache/cache_config_json.hpp"
+#include <algorithm>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -38,60 +39,39 @@ public:
   HakoPduErrorType open(const std::string &config_path) override {
     CacheConfig config;
     const auto result = load_cache_config(config_path, config);
-    if (result != HAKO_PDU_ERR_OK) {
-      return result;
-    }
+    if (result != HAKO_PDU_ERR_OK) return result;
     return configure(config);
   }
 
   HakoPduErrorType configure(const CacheConfig& config) noexcept override {
-    if (validate_cache_config(config) != HAKO_PDU_ERR_OK || config.mode != CacheMode::Latest) {
-      return HAKO_PDU_ERR_INVALID_CONFIG;
-    }
+    if (validate_cache_config(config) != HAKO_PDU_ERR_OK || config.mode != CacheMode::Latest) return HAKO_PDU_ERR_INVALID_CONFIG;
     return HAKO_PDU_ERR_OK;
   }
 
-  HakoPduErrorType close() noexcept override {
-    std::lock_guard<std::mutex> lock(mtx_);
-    buffers_.clear(); pending_order_.clear(); pending_keys_.clear(); tracked_keys_.clear(); is_running_ = false;
-    return HAKO_PDU_ERR_OK;
-  }
+  HakoPduErrorType close() noexcept override { std::lock_guard<std::mutex> lock(mtx_); buffers_.clear(); pending_order_.clear(); pending_keys_.clear(); tracked_keys_.clear(); is_running_ = false; return HAKO_PDU_ERR_OK; }
   HakoPduErrorType start() noexcept override { is_running_ = true; return HAKO_PDU_ERR_OK; }
   HakoPduErrorType stop() noexcept override { is_running_ = false; return HAKO_PDU_ERR_OK; }
   HakoPduErrorType is_running(bool &running) noexcept override { running = is_running_; return HAKO_PDU_ERR_OK; }
 
   HakoPduErrorType write(const PduResolvedKey &pdu_key, std::span<const std::byte> data) noexcept override {
     if (!is_running_) return HAKO_PDU_ERR_NOT_RUNNING;
-    std::lock_guard<std::mutex> lock(mtx_);
-    auto &entry = buffers_[pdu_key]; entry.data.assign(data.begin(), data.end()); entry.has_data = true;
+    std::lock_guard<std::mutex> lock(mtx_); auto &entry = buffers_[pdu_key]; entry.data.assign(data.begin(), data.end()); entry.has_data = true;
     if (!pending_keys_[pdu_key]) { pending_order_.push_back(pdu_key); pending_keys_[pdu_key] = true; }
     return HAKO_PDU_ERR_OK;
   }
   HakoPduErrorType read(const PduResolvedKey &pdu_key, std::span<std::byte> data, size_t &received_size) noexcept override {
     if (!is_running_) return HAKO_PDU_ERR_NOT_RUNNING;
-    std::lock_guard<std::mutex> lock(mtx_);
-    auto it = buffers_.find(pdu_key);
+    std::lock_guard<std::mutex> lock(mtx_); auto it = buffers_.find(pdu_key);
     if (it == buffers_.end() || !it->second.has_data) { received_size = 0; return HAKO_PDU_ERR_NO_ENTRY; }
-    const auto &src = it->second.data;
-    if (data.size() < src.size()) { received_size = src.size(); return HAKO_PDU_ERR_NO_SPACE; }
-    std::copy(src.begin(), src.end(), data.begin()); received_size = src.size(); pending_keys_[pdu_key] = false;
-    return HAKO_PDU_ERR_OK;
+    const auto &src = it->second.data; if (data.size() < src.size()) { received_size = src.size(); return HAKO_PDU_ERR_NO_SPACE; }
+    std::copy(src.begin(), src.end(), data.begin()); received_size = src.size(); pending_keys_[pdu_key] = false; return HAKO_PDU_ERR_OK;
   }
   HakoPduErrorType set_recv_event(const PduResolvedKey &pdu_key) noexcept override { std::lock_guard<std::mutex> lock(mtx_); tracked_keys_[pdu_key] = true; return HAKO_PDU_ERR_OK; }
-  HakoPduErrorType get_pending_count(size_t &out_count) noexcept override {
-    std::lock_guard<std::mutex> lock(mtx_); out_count = 0;
-    for (const auto &[key, tracked] : tracked_keys_) if (tracked) { auto it = pending_keys_.find(key); if (it != pending_keys_.end() && it->second) ++out_count; }
-    return HAKO_PDU_ERR_OK;
-  }
+  HakoPduErrorType get_pending_count(size_t &out_count) noexcept override { std::lock_guard<std::mutex> lock(mtx_); out_count = 0; for (const auto &[key, tracked] : tracked_keys_) if (tracked) { auto it = pending_keys_.find(key); if (it != pending_keys_.end() && it->second) ++out_count; } return HAKO_PDU_ERR_OK; }
   HakoPduErrorType read_next(PduRecord &out) noexcept override {
     if (!is_running_) return HAKO_PDU_ERR_NOT_RUNNING;
     std::lock_guard<std::mutex> lock(mtx_);
-    while (!pending_order_.empty()) {
-      const auto key = pending_order_.front(); pending_order_.pop_front();
-      auto pending_it = pending_keys_.find(key); if (pending_it == pending_keys_.end() || !pending_it->second) continue;
-      auto buffer_it = buffers_.find(key); if (buffer_it == buffers_.end() || !buffer_it->second.has_data) { pending_it->second = false; continue; }
-      out.key = key; out.timestamp_ns = 0; out.payload = buffer_it->second.data; pending_it->second = false; return HAKO_PDU_ERR_OK;
-    }
+    while (!pending_order_.empty()) { const auto key = pending_order_.front(); pending_order_.pop_front(); auto pending_it = pending_keys_.find(key); if (pending_it == pending_keys_.end() || !pending_it->second) continue; auto buffer_it = buffers_.find(key); if (buffer_it == buffers_.end() || !buffer_it->second.has_data) { pending_it->second = false; continue; } out.key = key; out.timestamp_ns = 0; out.payload = buffer_it->second.data; pending_it->second = false; return HAKO_PDU_ERR_OK; }
     return HAKO_PDU_ERR_NO_ENTRY;
   }
 };

--- a/include/hakoniwa/pdu/cache/cache_buffer.hpp
+++ b/include/hakoniwa/pdu/cache/cache_buffer.hpp
@@ -1,14 +1,13 @@
 #pragma once
 
 #include "hakoniwa/pdu/cache/cache.hpp"
-#include <fstream>
+#include "hakoniwa/pdu/cache/cache_config_json.hpp"
 #include <memory>
 #include <mutex>
 #include <string>
 #include <deque>
 #include <unordered_map>
 #include <vector>
-#include <nlohmann/json.hpp>
 #include <iostream>
 
 namespace hakoniwa {
@@ -37,137 +36,61 @@ public:
   PduLatestBuffer &operator=(PduLatestBuffer &&) = delete;
 
   HakoPduErrorType open(const std::string &config_path) override {
-    std::ifstream ifs(config_path);
-    if (!ifs.is_open()) {
-      return HAKO_PDU_ERR_FILE_NOT_FOUND;
+    CacheConfig config;
+    const auto result = load_cache_config(config_path, config);
+    if (result != HAKO_PDU_ERR_OK) {
+      return result;
     }
-    nlohmann::json json_config;
-    try {
-      ifs >> json_config;
-      if (!json_config.contains("type") || json_config["type"] != "buffer") {
-        return HAKO_PDU_ERR_INVALID_CONFIG;
-      }
-      if (!json_config.contains("store") || !json_config["store"].contains("mode") || json_config["store"]["mode"] != "latest") {
-        return HAKO_PDU_ERR_INVALID_CONFIG;
-      }
-    } catch (const nlohmann::json::exception&) {
-      return HAKO_PDU_ERR_INVALID_JSON;
+    return configure(config);
+  }
+
+  HakoPduErrorType configure(const CacheConfig& config) noexcept override {
+    if (validate_cache_config(config) != HAKO_PDU_ERR_OK || config.mode != CacheMode::Latest) {
+      return HAKO_PDU_ERR_INVALID_CONFIG;
     }
     return HAKO_PDU_ERR_OK;
   }
 
   HakoPduErrorType close() noexcept override {
     std::lock_guard<std::mutex> lock(mtx_);
-    buffers_.clear();
-    pending_order_.clear();
-    pending_keys_.clear();
-    tracked_keys_.clear();
-    is_running_ = false;
+    buffers_.clear(); pending_order_.clear(); pending_keys_.clear(); tracked_keys_.clear(); is_running_ = false;
     return HAKO_PDU_ERR_OK;
   }
+  HakoPduErrorType start() noexcept override { is_running_ = true; return HAKO_PDU_ERR_OK; }
+  HakoPduErrorType stop() noexcept override { is_running_ = false; return HAKO_PDU_ERR_OK; }
+  HakoPduErrorType is_running(bool &running) noexcept override { running = is_running_; return HAKO_PDU_ERR_OK; }
 
-  HakoPduErrorType start() noexcept override {
-    is_running_ = true;
-    return HAKO_PDU_ERR_OK;
-  }
-
-  HakoPduErrorType stop() noexcept override {
-    is_running_ = false;
-    return HAKO_PDU_ERR_OK;
-  }
-
-  HakoPduErrorType is_running(bool &running) noexcept override {
-    running = is_running_;
-    return HAKO_PDU_ERR_OK;
-  }
-
-  HakoPduErrorType write(const PduResolvedKey &pdu_key,
-                         std::span<const std::byte> data) noexcept override {
-    if (!is_running_) {
-        return HAKO_PDU_ERR_NOT_RUNNING;
-    }
+  HakoPduErrorType write(const PduResolvedKey &pdu_key, std::span<const std::byte> data) noexcept override {
+    if (!is_running_) return HAKO_PDU_ERR_NOT_RUNNING;
     std::lock_guard<std::mutex> lock(mtx_);
-    auto &entry = buffers_[pdu_key];
-    entry.data.assign(data.begin(), data.end());
-    entry.has_data = true;
-    if (!pending_keys_[pdu_key]) {
-      pending_order_.push_back(pdu_key);
-      pending_keys_[pdu_key] = true;
-    }
+    auto &entry = buffers_[pdu_key]; entry.data.assign(data.begin(), data.end()); entry.has_data = true;
+    if (!pending_keys_[pdu_key]) { pending_order_.push_back(pdu_key); pending_keys_[pdu_key] = true; }
     return HAKO_PDU_ERR_OK;
   }
-
-  HakoPduErrorType read(const PduResolvedKey &pdu_key,
-                        std::span<std::byte> data,
-                        size_t &received_size) noexcept override {
-    if (!is_running_) {
-        return HAKO_PDU_ERR_NOT_RUNNING;
-    }
+  HakoPduErrorType read(const PduResolvedKey &pdu_key, std::span<std::byte> data, size_t &received_size) noexcept override {
+    if (!is_running_) return HAKO_PDU_ERR_NOT_RUNNING;
     std::lock_guard<std::mutex> lock(mtx_);
     auto it = buffers_.find(pdu_key);
-    if (it == buffers_.end() || !it->second.has_data) {
-      received_size = 0;
-      return HAKO_PDU_ERR_NO_ENTRY;
-    }
-
+    if (it == buffers_.end() || !it->second.has_data) { received_size = 0; return HAKO_PDU_ERR_NO_ENTRY; }
     const auto &src = it->second.data;
-    if (data.size() < src.size()) {
-      received_size = src.size();
-      return HAKO_PDU_ERR_NO_SPACE;
-    }
-
-    std::copy(src.begin(), src.end(), data.begin());
-    received_size = src.size();
-    pending_keys_[pdu_key] = false;
-
+    if (data.size() < src.size()) { received_size = src.size(); return HAKO_PDU_ERR_NO_SPACE; }
+    std::copy(src.begin(), src.end(), data.begin()); received_size = src.size(); pending_keys_[pdu_key] = false;
     return HAKO_PDU_ERR_OK;
   }
-
-  HakoPduErrorType set_recv_event(const PduResolvedKey &pdu_key) noexcept override {
-    std::lock_guard<std::mutex> lock(mtx_);
-    tracked_keys_[pdu_key] = true;
-    return HAKO_PDU_ERR_OK;
-  }
-
+  HakoPduErrorType set_recv_event(const PduResolvedKey &pdu_key) noexcept override { std::lock_guard<std::mutex> lock(mtx_); tracked_keys_[pdu_key] = true; return HAKO_PDU_ERR_OK; }
   HakoPduErrorType get_pending_count(size_t &out_count) noexcept override {
-    std::lock_guard<std::mutex> lock(mtx_);
-    out_count = 0;
-    for (const auto &[key, tracked] : tracked_keys_) {
-      if (!tracked) {
-        continue;
-      }
-      auto pending_it = pending_keys_.find(key);
-      if (pending_it != pending_keys_.end() && pending_it->second) {
-        ++out_count;
-      }
-    }
+    std::lock_guard<std::mutex> lock(mtx_); out_count = 0;
+    for (const auto &[key, tracked] : tracked_keys_) if (tracked) { auto it = pending_keys_.find(key); if (it != pending_keys_.end() && it->second) ++out_count; }
     return HAKO_PDU_ERR_OK;
   }
-
   HakoPduErrorType read_next(PduRecord &out) noexcept override {
-    if (!is_running_) {
-      return HAKO_PDU_ERR_NOT_RUNNING;
-    }
+    if (!is_running_) return HAKO_PDU_ERR_NOT_RUNNING;
     std::lock_guard<std::mutex> lock(mtx_);
     while (!pending_order_.empty()) {
-      const auto key = pending_order_.front();
-      pending_order_.pop_front();
-
-      auto pending_it = pending_keys_.find(key);
-      if (pending_it == pending_keys_.end() || !pending_it->second) {
-        continue;
-      }
-      auto buffer_it = buffers_.find(key);
-      if (buffer_it == buffers_.end() || !buffer_it->second.has_data) {
-        pending_it->second = false;
-        continue;
-      }
-
-      out.key = key;
-      out.timestamp_ns = 0;
-      out.payload = buffer_it->second.data;
-      pending_it->second = false;
-      return HAKO_PDU_ERR_OK;
+      const auto key = pending_order_.front(); pending_order_.pop_front();
+      auto pending_it = pending_keys_.find(key); if (pending_it == pending_keys_.end() || !pending_it->second) continue;
+      auto buffer_it = buffers_.find(key); if (buffer_it == buffers_.end() || !buffer_it->second.has_data) { pending_it->second = false; continue; }
+      out.key = key; out.timestamp_ns = 0; out.payload = buffer_it->second.data; pending_it->second = false; return HAKO_PDU_ERR_OK;
     }
     return HAKO_PDU_ERR_NO_ENTRY;
   }

--- a/include/hakoniwa/pdu/cache/cache_config_json.hpp
+++ b/include/hakoniwa/pdu/cache/cache_config_json.hpp
@@ -29,12 +29,12 @@ inline HakoPduErrorType cache_config_to_json(
     }
 
     out = {
-        {"name", config.name},
         {"type", "buffer"},
-        {"mode", cache_mode_to_string(config.mode)},
+        {"name", config.name},
+        {"store", {{"mode", cache_mode_to_string(config.mode)}}},
     };
     if (config.mode == CacheMode::Queue) {
-        out["depth"] = config.depth;
+        out["store"]["depth"] = config.depth;
     }
     return HAKO_PDU_ERR_OK;
 }
@@ -48,21 +48,22 @@ inline HakoPduErrorType cache_config_from_json(
             !input.contains("name") || !input["name"].is_string() ||
             !input.contains("type") || !input["type"].is_string() ||
             input["type"].get<std::string>() != "buffer" ||
-            !input.contains("mode") || !input["mode"].is_string()) {
+            !input.contains("store") || !input["store"].is_object() ||
+            !input["store"].contains("mode") || !input["store"]["mode"].is_string()) {
             return HAKO_PDU_ERR_INVALID_CONFIG;
         }
 
         const auto name = input["name"].get<std::string>();
-        const auto mode = input["mode"].get<std::string>();
+        const auto mode = input["store"]["mode"].get<std::string>();
         CacheConfig config;
         if (mode == "latest") {
             config = make_latest_cache(name);
         }
         else if (mode == "queue") {
-            if (!input.contains("depth") || !input["depth"].is_number_unsigned()) {
+            if (!input["store"].contains("depth") || !input["store"]["depth"].is_number_unsigned()) {
                 return HAKO_PDU_ERR_INVALID_CONFIG;
             }
-            config = make_queue_cache(name, input["depth"].get<std::size_t>());
+            config = make_queue_cache(name, input["store"]["depth"].get<std::size_t>());
         }
         else {
             return HAKO_PDU_ERR_INVALID_CONFIG;
@@ -103,13 +104,16 @@ inline HakoPduErrorType load_cache_config(
 {
     std::ifstream ifs(path);
     if (!ifs.is_open()) {
-        return HAKO_PDU_ERR_INVALID_CONFIG;
+        return HAKO_PDU_ERR_FILE_NOT_FOUND;
     }
 
     try {
         nlohmann::json json;
         ifs >> json;
         return cache_config_from_json(json, out);
+    }
+    catch (const nlohmann::json::parse_error&) {
+        return HAKO_PDU_ERR_INVALID_JSON;
     }
     catch (...) {
         return HAKO_PDU_ERR_INVALID_CONFIG;

--- a/include/hakoniwa/pdu/cache/cache_queue.hpp
+++ b/include/hakoniwa/pdu/cache/cache_queue.hpp
@@ -1,11 +1,10 @@
 #pragma once
 
 #include "hakoniwa/pdu/cache/cache.hpp"
+#include "hakoniwa/pdu/cache/cache_config_json.hpp"
 #include <deque>
-#include <fstream>
 #include <memory>
 #include <mutex>
-#include <nlohmann/json.hpp>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -37,142 +36,65 @@ public:
   PduLatestQueue &operator=(PduLatestQueue &&) = delete;
 
   HakoPduErrorType open(const std::string &config_path) override {
-    std::ifstream ifs(config_path);
-    if (!ifs.is_open()) {
-      return HAKO_PDU_ERR_FILE_NOT_FOUND;
+    CacheConfig config;
+    const auto result = load_cache_config(config_path, config);
+    if (result != HAKO_PDU_ERR_OK) {
+      return result;
     }
-    nlohmann::json json_config;
-    try {
-      ifs >> json_config;
-      if (json_config.contains("store") && json_config["store"].contains("depth")) {
-        depth_ = json_config["store"]["depth"].get<int>();
-      }
-    } catch (const nlohmann::json::parse_error &) {
-      return HAKO_PDU_ERR_INVALID_JSON;
-    } catch (const nlohmann::json::exception &) {
+    return configure(config);
+  }
+
+  HakoPduErrorType configure(const CacheConfig& config) noexcept override {
+    if (validate_cache_config(config) != HAKO_PDU_ERR_OK || config.mode != CacheMode::Queue) {
       return HAKO_PDU_ERR_INVALID_CONFIG;
     }
-    if (depth_ == 0) {
-        depth_ = 1; // depth must be >= 1
-    }
+    depth_ = config.depth;
     return HAKO_PDU_ERR_OK;
   }
 
   HakoPduErrorType close() noexcept override {
     std::lock_guard<std::mutex> lock(mtx_);
-    queues_.clear();
-    arrival_order_.clear();
-    tracked_keys_.clear();
-    is_running_ = false;
+    queues_.clear(); arrival_order_.clear(); tracked_keys_.clear(); is_running_ = false;
     return HAKO_PDU_ERR_OK;
   }
+  HakoPduErrorType start() noexcept override { is_running_ = true; return HAKO_PDU_ERR_OK; }
+  HakoPduErrorType stop() noexcept override { is_running_ = false; return HAKO_PDU_ERR_OK; }
+  HakoPduErrorType is_running(bool &running) noexcept override { running = is_running_; return HAKO_PDU_ERR_OK; }
 
-  HakoPduErrorType start() noexcept override {
-    is_running_ = true;
-    return HAKO_PDU_ERR_OK;
-  }
-
-  HakoPduErrorType stop() noexcept override {
-    is_running_ = false;
-    return HAKO_PDU_ERR_OK;
-  }
-
-  HakoPduErrorType is_running(bool &running) noexcept override {
-    running = is_running_;
-    return HAKO_PDU_ERR_OK;
-  }
-
-  HakoPduErrorType write(const PduResolvedKey &pdu_key,
-                         std::span<const std::byte> data) noexcept override {
-    if (!is_running_) {
-        return HAKO_PDU_ERR_NOT_RUNNING;
-    }
+  HakoPduErrorType write(const PduResolvedKey &pdu_key, std::span<const std::byte> data) noexcept override {
+    if (!is_running_) return HAKO_PDU_ERR_NOT_RUNNING;
     std::lock_guard<std::mutex> lock(mtx_);
-    auto &q = queues_[pdu_key].queue;
-    q.emplace_back(data.begin(), data.end());
-    arrival_order_.push_back(pdu_key);
-
+    auto &q = queues_[pdu_key].queue; q.emplace_back(data.begin(), data.end()); arrival_order_.push_back(pdu_key);
     if (q.size() > depth_) {
       q.pop_front();
       auto it = std::find(arrival_order_.begin(), arrival_order_.end(), pdu_key);
-      if (it != arrival_order_.end()) {
-        arrival_order_.erase(it);
-      }
+      if (it != arrival_order_.end()) arrival_order_.erase(it);
     }
     return HAKO_PDU_ERR_OK;
   }
-
-  HakoPduErrorType read(const PduResolvedKey &pdu_key,
-                        std::span<std::byte> data,
-                        size_t &received_size) noexcept override {
-    if (!is_running_) {
-        return HAKO_PDU_ERR_NOT_RUNNING;
-    }
+  HakoPduErrorType read(const PduResolvedKey &pdu_key, std::span<std::byte> data, size_t &received_size) noexcept override {
+    if (!is_running_) return HAKO_PDU_ERR_NOT_RUNNING;
     std::lock_guard<std::mutex> lock(mtx_);
-    auto it = queues_.find(pdu_key);
-    if (it == queues_.end() || it->second.queue.empty()) {
-      received_size = 0;
-      return HAKO_PDU_ERR_NO_ENTRY;
-    }
-
-    auto &q = it->second.queue;
-    const auto &src = q.front(); 
-
-    if (data.size() < src.size()) {
-      received_size = src.size();
-      return HAKO_PDU_ERR_NO_SPACE;
-    }
-
-    std::copy(src.begin(), src.end(), data.begin());
-    received_size = src.size();
-
-    q.pop_front();
-    auto order_it = std::find(arrival_order_.begin(), arrival_order_.end(), pdu_key);
-    if (order_it != arrival_order_.end()) {
-      arrival_order_.erase(order_it);
-    }
-
+    auto it = queues_.find(pdu_key); if (it == queues_.end() || it->second.queue.empty()) { received_size = 0; return HAKO_PDU_ERR_NO_ENTRY; }
+    auto &q = it->second.queue; const auto &src = q.front();
+    if (data.size() < src.size()) { received_size = src.size(); return HAKO_PDU_ERR_NO_SPACE; }
+    std::copy(src.begin(), src.end(), data.begin()); received_size = src.size(); q.pop_front();
+    auto order_it = std::find(arrival_order_.begin(), arrival_order_.end(), pdu_key); if (order_it != arrival_order_.end()) arrival_order_.erase(order_it);
     return HAKO_PDU_ERR_OK;
   }
-
-  HakoPduErrorType set_recv_event(const PduResolvedKey &pdu_key) noexcept override {
-    std::lock_guard<std::mutex> lock(mtx_);
-    tracked_keys_[pdu_key] = true;
-    return HAKO_PDU_ERR_OK;
-  }
-
+  HakoPduErrorType set_recv_event(const PduResolvedKey &pdu_key) noexcept override { std::lock_guard<std::mutex> lock(mtx_); tracked_keys_[pdu_key] = true; return HAKO_PDU_ERR_OK; }
   HakoPduErrorType get_pending_count(size_t &out_count) noexcept override {
-    std::lock_guard<std::mutex> lock(mtx_);
-    out_count = 0;
-    for (const auto &key : arrival_order_) {
-      auto tracked_it = tracked_keys_.find(key);
-      if (tracked_it != tracked_keys_.end() && tracked_it->second) {
-        ++out_count;
-      }
-    }
+    std::lock_guard<std::mutex> lock(mtx_); out_count = 0;
+    for (const auto &key : arrival_order_) { auto it = tracked_keys_.find(key); if (it != tracked_keys_.end() && it->second) ++out_count; }
     return HAKO_PDU_ERR_OK;
   }
-
   HakoPduErrorType read_next(PduRecord &out) noexcept override {
-    if (!is_running_) {
-      return HAKO_PDU_ERR_NOT_RUNNING;
-    }
+    if (!is_running_) return HAKO_PDU_ERR_NOT_RUNNING;
     std::lock_guard<std::mutex> lock(mtx_);
     while (!arrival_order_.empty()) {
-      const auto key = arrival_order_.front();
-      arrival_order_.pop_front();
-
-      auto it = queues_.find(key);
-      if (it == queues_.end() || it->second.queue.empty()) {
-        continue;
-      }
-
-      auto &payload = it->second.queue.front();
-      out.key = key;
-      out.timestamp_ns = 0;
-      out.payload = payload;
-      it->second.queue.pop_front();
-      return HAKO_PDU_ERR_OK;
+      const auto key = arrival_order_.front(); arrival_order_.pop_front();
+      auto it = queues_.find(key); if (it == queues_.end() || it->second.queue.empty()) continue;
+      auto &payload = it->second.queue.front(); out.key = key; out.timestamp_ns = 0; out.payload = payload; it->second.queue.pop_front(); return HAKO_PDU_ERR_OK;
     }
     return HAKO_PDU_ERR_NO_ENTRY;
   }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,7 +17,6 @@ if(TARGET hako_pdu_storage_debug)
   target_compile_definitions(endpoint_test PRIVATE HAKO_PDU_STORAGE_DEBUG_EXE="$<TARGET_FILE:hako_pdu_storage_debug>")
 endif()
 
-# Add OS-specific logic for Hakoniwa core library for the test target
 if(APPLE)
   target_include_directories(endpoint_test
     PRIVATE
@@ -28,7 +27,6 @@ if(APPLE)
       /usr/local/hakoniwa/lib/libassets.dylib
   )
 endif()
-
 
 add_test(NAME endpoint_test COMMAND endpoint_test)
 
@@ -44,5 +42,16 @@ target_link_libraries(cache_config_test
 
 add_test(NAME cache_config_test COMMAND cache_config_test)
 
-# Set the working directory to the project root so tests can find the config files
+add_executable(cache_runtime_config_test
+  cache_runtime_config_test.cpp
+)
+
+target_link_libraries(cache_runtime_config_test
+  PRIVATE
+    hakoniwa_pdu_endpoint
+    GTest::gtest_main
+)
+
+add_test(NAME cache_runtime_config_test COMMAND cache_runtime_config_test)
+
 set_tests_properties(endpoint_test PROPERTIES WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}")

--- a/test/cache_runtime_config_test.cpp
+++ b/test/cache_runtime_config_test.cpp
@@ -1,0 +1,53 @@
+#include <gtest/gtest.h>
+
+#include "hakoniwa/pdu/cache/cache_buffer.hpp"
+#include "hakoniwa/pdu/cache/cache_queue.hpp"
+#include "hakoniwa/pdu/cache/cache_config.hpp"
+
+#include <array>
+
+namespace {
+
+using hakoniwa::pdu::PduLatestBuffer;
+using hakoniwa::pdu::PduLatestQueue;
+using hakoniwa::pdu::PduResolvedKey;
+using hakoniwa::pdu::make_latest_cache;
+using hakoniwa::pdu::make_queue_cache;
+
+TEST(CacheRuntimeConfigTest, LatestAcceptsOnlyLatestConfig)
+{
+    PduLatestBuffer cache;
+    EXPECT_EQ(cache.configure(make_latest_cache("latest")), HAKO_PDU_ERR_OK);
+    EXPECT_EQ(cache.configure(make_queue_cache("queue", 2)), HAKO_PDU_ERR_INVALID_CONFIG);
+}
+
+TEST(CacheRuntimeConfigTest, QueueAcceptsOnlyQueueConfig)
+{
+    PduLatestQueue cache;
+    EXPECT_EQ(cache.configure(make_queue_cache("queue", 2)), HAKO_PDU_ERR_OK);
+    EXPECT_EQ(cache.configure(make_latest_cache("latest")), HAKO_PDU_ERR_INVALID_CONFIG);
+}
+
+TEST(CacheRuntimeConfigTest, QueueDepthComesFromMemoryConfig)
+{
+    PduLatestQueue cache;
+    ASSERT_EQ(cache.configure(make_queue_cache("queue", 2)), HAKO_PDU_ERR_OK);
+    ASSERT_EQ(cache.start(), HAKO_PDU_ERR_OK);
+
+    const PduResolvedKey key{"robot", 1};
+    const std::array<std::byte, 1> first{std::byte{1}};
+    const std::array<std::byte, 1> second{std::byte{2}};
+    const std::array<std::byte, 1> third{std::byte{3}};
+    ASSERT_EQ(cache.write(key, first), HAKO_PDU_ERR_OK);
+    ASSERT_EQ(cache.write(key, second), HAKO_PDU_ERR_OK);
+    ASSERT_EQ(cache.write(key, third), HAKO_PDU_ERR_OK);
+
+    std::array<std::byte, 1> out{};
+    size_t received = 0;
+    ASSERT_EQ(cache.read(key, out, received), HAKO_PDU_ERR_OK);
+    EXPECT_EQ(out[0], std::byte{2});
+    ASSERT_EQ(cache.read(key, out, received), HAKO_PDU_ERR_OK);
+    EXPECT_EQ(out[0], std::byte{3});
+}
+
+} // namespace


### PR DESCRIPTION
## Summary

Implements Step 3 of the typed cache configuration work.

- add `PduCache::configure(const CacheConfig&)`
- make latest/queue cache implementations consume `CacheConfig` directly
- keep existing `open(path)` as a compatibility wrapper: `load_cache_config(path) -> configure(config)`
- verify queue depth is applied from in-memory configuration
- keep Endpoint integration out of scope

## Compatibility fix

While wiring the existing file path into the common `CacheConfig` path, this PR also corrects the persistence JSON mapping from PR #47 to preserve the existing cache schema shape:

```json
{
  "type": "buffer",
  "name": "...",
  "store": {
    "mode": "latest|queue",
    "depth": 16
  }
}
```

It also preserves `FILE_NOT_FOUND` and invalid-JSON error behavior for file loading.

## Scope

This PR stays inside the Cache layer. It does **not** change Endpoint initialization or comm configuration. Endpoint composition is the next step.