### PR TITLE
refactor: route endpoint cache through CacheConfig

### DIFF
--- a/include/hakoniwa/pdu/endpoint.hpp
+++ b/include/hakoniwa/pdu/endpoint.hpp
@@ -3,6 +3,7 @@
 #include "hakoniwa/pdu/endpoint_types.hpp"
 #include "hakoniwa/pdu/pdu_definition.hpp" // Added
 #include "hakoniwa/pdu/cache/cache.hpp"
+#include "hakoniwa/pdu/cache/cache_config_json.hpp"
 #include "hakoniwa/pdu/comm/comm.hpp"
 #include "hakoniwa/pdu/pdu_factory.hpp"
 #include <nlohmann/json.hpp>
@@ -144,7 +145,8 @@ public:
                 return err;
             }
 
-            // Cache is mandatory
+            // Cache is mandatory. The file is consumed only at the endpoint boundary;
+            // the cache runtime receives the typed in-memory CacheConfig.
             if (!config.contains("cache") || config["cache"].is_null()) {
                 std::cerr << "PDU Cache configuration is missing." << std::endl;
                 return HAKO_PDU_ERR_INVALID_CONFIG;
@@ -152,15 +154,16 @@ public:
             std::string cache_config_path = config["cache"].get<std::string>();
             auto resolved_cache_config_path = resolve_under_base(base_dir, cache_config_path);
 
-            cache_ = create_pdu_cache(resolved_cache_config_path.string());
-            if (!cache_) {
-                std::cerr << "Failed to create PDU Cache module: " << resolved_cache_config_path << std::endl;
-                return HAKO_PDU_ERR_INVALID_CONFIG;
-            }
-            err = cache_->open(resolved_cache_config_path.string());
+            CacheConfig cache_config;
+            err = load_cache_config(resolved_cache_config_path.string(), cache_config);
             if (err != HAKO_PDU_ERR_OK) {
-                std::cerr << "Failed to open PDU Cache: " << static_cast<int>(err) << std::endl;
+                std::cerr << "Failed to load PDU Cache configuration: " << static_cast<int>(err) << std::endl;
                 return err;
+            }
+            cache_ = create_pdu_cache(cache_config);
+            if (!cache_) {
+                std::cerr << "Failed to create PDU Cache module from in-memory configuration." << std::endl;
+                return HAKO_PDU_ERR_INVALID_CONFIG;
             }
             // Comm is optional
             if (config.contains("comm") && !config["comm"].is_null()) {

--- a/include/hakoniwa/pdu/pdu_factory.hpp
+++ b/include/hakoniwa/pdu/pdu_factory.hpp
@@ -1,12 +1,20 @@
 #pragma once
 
 #include "hakoniwa/pdu/cache/cache.hpp"
+#include "hakoniwa/pdu/cache/cache_config.hpp"
 #include "hakoniwa/pdu/comm/comm.hpp"
 #include <memory>
 #include <string>
 
 namespace hakoniwa {
 namespace pdu {
+
+/**
+ * @brief Creates a PDU cache instance from an in-memory cache configuration.
+ * @param config Typed cache configuration.
+ * @return A unique_ptr to the created PduCache, or nullptr on failure.
+ */
+std::unique_ptr<PduCache> create_pdu_cache(const CacheConfig& config);
 
 /**
  * @brief Creates a PDU cache instance based on the provided configuration file.

--- a/src/pdu_factory.cpp
+++ b/src/pdu_factory.cpp
@@ -1,6 +1,7 @@
 #include "hakoniwa/pdu/pdu_factory.hpp"
 #include "hakoniwa/pdu/cache/cache_buffer.hpp"
 #include "hakoniwa/pdu/cache/cache_queue.hpp"
+#include "hakoniwa/pdu/cache/cache_config_json.hpp"
 #include "hakoniwa/pdu/comm/comm_tcp.hpp"
 #include "hakoniwa/pdu/comm/comm_udp.hpp"
 #ifdef HAKO_PDU_ENDPOINT_HAS_HAKONIWA_CORE
@@ -22,31 +23,35 @@
 namespace hakoniwa {
 namespace pdu {
 
+std::unique_ptr<PduCache> create_pdu_cache(const CacheConfig& config) {
+    if (validate_cache_config(config) != HAKO_PDU_ERR_OK) {
+        return nullptr;
+    }
+
+    std::unique_ptr<PduCache> cache;
+    switch (config.mode) {
+    case CacheMode::Latest:
+        cache = std::make_unique<PduLatestBuffer>();
+        break;
+    case CacheMode::Queue:
+        cache = std::make_unique<PduLatestQueue>();
+        break;
+    }
+
+    if (!cache || cache->configure(config) != HAKO_PDU_ERR_OK) {
+        return nullptr;
+    }
+    return cache;
+}
+
 std::unique_ptr<PduCache> create_pdu_cache(const std::string& config_path) {
-    std::ifstream ifs(config_path);
-    if (!ifs.is_open()) {
-        // Simple error logging, a more robust logging mechanism should be used in a real application.
-        std::cerr << "PduCache Factory Error: Failed to open config file: " << config_path << std::endl;
+    CacheConfig config;
+    const auto result = load_cache_config(config_path, config);
+    if (result != HAKO_PDU_ERR_OK) {
+        std::cerr << "PduCache Factory Error: Failed to load config file: " << config_path << std::endl;
         return nullptr;
     }
-
-    nlohmann::json config;
-    try {
-        ifs >> config;
-        std::string mode = config.at("store").at("mode").get<std::string>();
-
-        if (mode == "latest") {
-            return std::make_unique<PduLatestBuffer>();
-        } else if (mode == "queue") {
-            return std::make_unique<PduLatestQueue>();
-        } else {
-            std::cerr << "PduCache Factory Error: Unknown cache mode '" << mode << "' in " << config_path << std::endl;
-            return nullptr;
-        }
-    } catch (const nlohmann::json::exception& e) {
-        std::cerr << "PduCache Factory Error: JSON parsing/access failed for " << config_path << ". Details: " << e.what() << std::endl;
-        return nullptr;
-    }
+    return create_pdu_cache(config);
 }
 
 std::shared_ptr<PduComm> create_pdu_comm(const std::string& config_path) {

--- a/test/cache_runtime_config_test.cpp
+++ b/test/cache_runtime_config_test.cpp
@@ -3,6 +3,7 @@
 #include "hakoniwa/pdu/cache/cache_buffer.hpp"
 #include "hakoniwa/pdu/cache/cache_queue.hpp"
 #include "hakoniwa/pdu/cache/cache_config.hpp"
+#include "hakoniwa/pdu/pdu_factory.hpp"
 
 #include <array>
 
@@ -11,6 +12,7 @@ namespace {
 using hakoniwa::pdu::PduLatestBuffer;
 using hakoniwa::pdu::PduLatestQueue;
 using hakoniwa::pdu::PduResolvedKey;
+using hakoniwa::pdu::create_pdu_cache;
 using hakoniwa::pdu::make_latest_cache;
 using hakoniwa::pdu::make_queue_cache;
 
@@ -48,6 +50,26 @@ TEST(CacheRuntimeConfigTest, QueueDepthComesFromMemoryConfig)
     EXPECT_EQ(out[0], std::byte{2});
     ASSERT_EQ(cache.read(key, out, received), HAKO_PDU_ERR_OK);
     EXPECT_EQ(out[0], std::byte{3});
+}
+
+TEST(CacheRuntimeConfigTest, FactoryCreatesConfiguredQueueFromMemory)
+{
+    auto cache = create_pdu_cache(make_queue_cache("queue", 2));
+    ASSERT_NE(cache, nullptr);
+    ASSERT_EQ(cache->start(), HAKO_PDU_ERR_OK);
+
+    const PduResolvedKey key{"robot", 1};
+    const std::array<std::byte, 1> first{std::byte{1}};
+    const std::array<std::byte, 1> second{std::byte{2}};
+    const std::array<std::byte, 1> third{std::byte{3}};
+    ASSERT_EQ(cache->write(key, first), HAKO_PDU_ERR_OK);
+    ASSERT_EQ(cache->write(key, second), HAKO_PDU_ERR_OK);
+    ASSERT_EQ(cache->write(key, third), HAKO_PDU_ERR_OK);
+
+    std::array<std::byte, 1> out{};
+    size_t received = 0;
+    ASSERT_EQ(cache->read(key, out, received), HAKO_PDU_ERR_OK);
+    EXPECT_EQ(out[0], std::byte{2});
 }
 
 } // namespace


### PR DESCRIPTION
## Summary

Implements Step 4 of the typed cache configuration work.

- Endpoint loads the referenced cache JSON once into `CacheConfig`
- Endpoint passes the in-memory `CacheConfig` to the cache factory
- add `create_pdu_cache(const CacheConfig&)`
- keep the existing path-based factory as a compatibility wrapper
- keep Comm configuration unchanged
- add a focused test for the typed factory path

## Runtime flow

Before:

```text
endpoint config
  -> cache config path
  -> factory reads cache JSON
  -> cache::open(path) reads cache JSON again
```

After:

```text
endpoint config
  -> cache config path
  -> load_cache_config()
  -> CacheConfig
  -> create_pdu_cache(CacheConfig)
  -> configured cache runtime
```

The cache file now exists only at the Endpoint boundary. The cache runtime itself is driven by the in-memory typed configuration.

## Scope

This PR intentionally does **not** change:
- Comm configuration/loading
- C API / Python / C# bindings
- endpoint top-level file-less construction

Those remain separate follow-up steps.