### PR TITLE
Add explicit Hakoniwa Core endpoint variants

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,9 +25,6 @@ include(CMakePackageConfigHelpers)
 
 # add_subdirectory を使って src と test ディレクトリの CMakeLists.txt を含める
 add_subdirectory(src)
-if(HAKO_PDU_ENDPOINT_ENABLE_HAKONIWA_CORE)
-  add_subdirectory(src/core_variants)
-endif()
 option(HAKO_PDU_ENDPOINT_BUILD_TOOLS "Build debug and inspection tools" ON)
 if(HAKO_PDU_ENDPOINT_BUILD_TOOLS)
   add_subdirectory(tools)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,9 @@ include(CMakePackageConfigHelpers)
 
 # add_subdirectory を使って src と test ディレクトリの CMakeLists.txt を含める
 add_subdirectory(src)
+if(HAKO_PDU_ENDPOINT_ENABLE_HAKONIWA_CORE)
+  add_subdirectory(src/core_variants)
+endif()
 option(HAKO_PDU_ENDPOINT_BUILD_TOOLS "Build debug and inspection tools" ON)
 if(HAKO_PDU_ENDPOINT_BUILD_TOOLS)
   add_subdirectory(tools)

--- a/src/core_variants/CMakeLists.txt
+++ b/src/core_variants/CMakeLists.txt
@@ -38,14 +38,13 @@ if(HAKO_PDU_ENDPOINT_ENABLE_MQTT)
   list(APPEND HAKO_ENDPOINT_VARIANT_COMMON_SRC ../comm_mqtt.cpp)
 endif()
 
-# Resolve the header-only dependencies already used by the legacy target.
-if(TARGET Boost::headers)
-  set(HAKO_ENDPOINT_VARIANT_BOOST_TARGET Boost::headers)
-elseif(TARGET Boost::boost)
-  set(HAKO_ENDPOINT_VARIANT_BOOST_TARGET Boost::boost)
-else()
-  message(FATAL_ERROR "Hakoniwa Core endpoint variants require the Boost target resolved by src/CMakeLists.txt")
+# Reuse the exact Boost dependency already resolved by src/CMakeLists.txt.
+# The legacy resolver may expose Boost::headers/Boost::boost, or it may create a
+# local fallback target and store that target name in HAKO_PDU_ENDPOINT_BOOST_TARGET.
+if(NOT DEFINED HAKO_PDU_ENDPOINT_BOOST_TARGET OR HAKO_PDU_ENDPOINT_BOOST_TARGET STREQUAL "")
+  message(FATAL_ERROR "Hakoniwa Core endpoint variants require the Boost dependency resolved by src/CMakeLists.txt")
 endif()
+set(HAKO_ENDPOINT_VARIANT_BOOST_TARGET ${HAKO_PDU_ENDPOINT_BOOST_TARGET})
 
 if(NOT TARGET nlohmann_json::nlohmann_json)
   message(FATAL_ERROR "Hakoniwa Core endpoint variants require nlohmann_json::nlohmann_json")

--- a/src/core_variants/CMakeLists.txt
+++ b/src/core_variants/CMakeLists.txt
@@ -38,13 +38,45 @@ if(HAKO_PDU_ENDPOINT_ENABLE_MQTT)
   list(APPEND HAKO_ENDPOINT_VARIANT_COMMON_SRC ../comm_mqtt.cpp)
 endif()
 
-# Reuse the exact Boost dependency already resolved by src/CMakeLists.txt.
-# The legacy resolver may expose Boost::headers/Boost::boost, or it may create a
-# local fallback target and store that target name in HAKO_PDU_ENDPOINT_BOOST_TARGET.
-if(NOT DEFINED HAKO_PDU_ENDPOINT_BOOST_TARGET OR HAKO_PDU_ENDPOINT_BOOST_TARGET STREQUAL "")
-  message(FATAL_ERROR "Hakoniwa Core endpoint variants require the Boost dependency resolved by src/CMakeLists.txt")
+# Resolve Boost independently here because imported package targets and ordinary
+# CMake variables created in src/CMakeLists.txt are directory-scoped. Keeping
+# this resolver local also avoids changing the legacy endpoint target.
+find_package(Boost 1.70 CONFIG QUIET)
+if(TARGET Boost::headers)
+  set(HAKO_ENDPOINT_VARIANT_BOOST_TARGET Boost::headers)
+elseif(TARGET Boost::boost)
+  set(HAKO_ENDPOINT_VARIANT_BOOST_TARGET Boost::boost)
+else()
+  set(HAKO_ENDPOINT_VARIANT_BOOST_INCLUDE_CANDIDATES "")
+  if(DEFINED VCPKG_INSTALLED_DIR AND DEFINED VCPKG_TARGET_TRIPLET)
+    list(APPEND HAKO_ENDPOINT_VARIANT_BOOST_INCLUDE_CANDIDATES
+      "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/include"
+    )
+  endif()
+  if(DEFINED CMAKE_TOOLCHAIN_FILE)
+    get_filename_component(HAKO_ENDPOINT_VARIANT_VCPKG_TOOLCHAIN_DIR "${CMAKE_TOOLCHAIN_FILE}" DIRECTORY)
+    get_filename_component(HAKO_ENDPOINT_VARIANT_VCPKG_SCRIPTS_DIR "${HAKO_ENDPOINT_VARIANT_VCPKG_TOOLCHAIN_DIR}" DIRECTORY)
+    get_filename_component(HAKO_ENDPOINT_VARIANT_VCPKG_ROOT "${HAKO_ENDPOINT_VARIANT_VCPKG_SCRIPTS_DIR}" DIRECTORY)
+    if(DEFINED VCPKG_TARGET_TRIPLET)
+      list(APPEND HAKO_ENDPOINT_VARIANT_BOOST_INCLUDE_CANDIDATES
+        "${HAKO_ENDPOINT_VARIANT_VCPKG_ROOT}/installed/${VCPKG_TARGET_TRIPLET}/include"
+      )
+    endif()
+  endif()
+
+  find_path(HAKO_ENDPOINT_VARIANT_BOOST_INCLUDE_DIR boost/asio.hpp
+    HINTS ${HAKO_ENDPOINT_VARIANT_BOOST_INCLUDE_CANDIDATES}
+  )
+  if(NOT HAKO_ENDPOINT_VARIANT_BOOST_INCLUDE_DIR)
+    message(FATAL_ERROR
+      "Boost headers were not found for Hakoniwa Core endpoint variants. Checked hints: ${HAKO_ENDPOINT_VARIANT_BOOST_INCLUDE_CANDIDATES}")
+  endif()
+  add_library(hako_pdu_endpoint_core_variant_boost_headers INTERFACE)
+  target_include_directories(hako_pdu_endpoint_core_variant_boost_headers INTERFACE
+    "${HAKO_ENDPOINT_VARIANT_BOOST_INCLUDE_DIR}"
+  )
+  set(HAKO_ENDPOINT_VARIANT_BOOST_TARGET hako_pdu_endpoint_core_variant_boost_headers)
 endif()
-set(HAKO_ENDPOINT_VARIANT_BOOST_TARGET ${HAKO_PDU_ENDPOINT_BOOST_TARGET})
 
 if(NOT TARGET nlohmann_json::nlohmann_json)
   message(FATAL_ERROR "Hakoniwa Core endpoint variants require nlohmann_json::nlohmann_json")

--- a/src/core_variants/CMakeLists.txt
+++ b/src/core_variants/CMakeLists.txt
@@ -1,0 +1,199 @@
+# Additional Hakoniwa Core endpoint variants.
+#
+# The legacy hakoniwa_pdu_endpoint target is intentionally left untouched.
+# These variants provide an explicit Core integration boundary so consumers can
+# depend on either the callback/assets API or the polling/shakoc API without
+# linking both Core frontends into the same endpoint library.
+
+set(HAKO_ENDPOINT_VARIANT_SOCKET_SRC "../socket_portability_posix.cpp")
+if(WIN32)
+  set(HAKO_ENDPOINT_VARIANT_SOCKET_SRC "../socket_portability_win.cpp")
+endif()
+
+set(HAKO_ENDPOINT_VARIANT_COMMON_SRC
+  ../c_endpoint.cpp
+  ../socket_utils.cpp
+  ${HAKO_ENDPOINT_VARIANT_SOCKET_SRC}
+  ../comm_udp.cpp
+  ../comm_tcp.cpp
+  ../comm_storage.cpp
+  ../comm_tcp_mux.cpp
+  ../comm_websocket.cpp
+  ../pdu_factory.cpp
+  ../comm_shm.cpp
+  ../pdu_definition.cpp
+  ../hakoniwa_time_source.cpp
+  ../endpoint_container.cpp
+  ../endpoint_comm_multiplexer.cpp
+)
+
+if(HAKO_PDU_ENDPOINT_ENABLE_ZENOH)
+  list(APPEND HAKO_ENDPOINT_VARIANT_COMMON_SRC
+    ../comm_zenoh.cpp
+    ../comm_rmw_zenoh.cpp
+  )
+endif()
+
+if(HAKO_PDU_ENDPOINT_ENABLE_MQTT)
+  list(APPEND HAKO_ENDPOINT_VARIANT_COMMON_SRC ../comm_mqtt.cpp)
+endif()
+
+# Resolve the header-only dependencies already used by the legacy target.
+if(TARGET Boost::headers)
+  set(HAKO_ENDPOINT_VARIANT_BOOST_TARGET Boost::headers)
+elseif(TARGET Boost::boost)
+  set(HAKO_ENDPOINT_VARIANT_BOOST_TARGET Boost::boost)
+else()
+  message(FATAL_ERROR "Hakoniwa Core endpoint variants require the Boost target resolved by src/CMakeLists.txt")
+endif()
+
+if(NOT TARGET nlohmann_json::nlohmann_json)
+  message(FATAL_ERROR "Hakoniwa Core endpoint variants require nlohmann_json::nlohmann_json")
+endif()
+
+# Resolve Core includes and the two mutually-exclusive Core frontend link sets.
+set(HAKO_ENDPOINT_VARIANT_CORE_INCLUDES "")
+set(HAKO_ENDPOINT_CALLBACK_CORE_LIBS "")
+set(HAKO_ENDPOINT_POLLING_CORE_LIBS "")
+
+if(TARGET assets AND TARGET shakoc)
+  if(DEFINED HAKO_PDU_ENDPOINT_HAKONIWA_CORE_SOURCE_DIR AND
+     EXISTS "${HAKO_PDU_ENDPOINT_HAKONIWA_CORE_SOURCE_DIR}/include")
+    list(APPEND HAKO_ENDPOINT_VARIANT_CORE_INCLUDES
+      "${HAKO_PDU_ENDPOINT_HAKONIWA_CORE_SOURCE_DIR}/include"
+      "${HAKO_PDU_ENDPOINT_HAKONIWA_CORE_SOURCE_DIR}/hakoniwa-pdu-registry/pdu/types"
+    )
+    if(EXISTS "${HAKO_PDU_ENDPOINT_HAKONIWA_CORE_SOURCE_DIR}/include/hakoniwa")
+      list(APPEND HAKO_ENDPOINT_VARIANT_CORE_INCLUDES
+        "${HAKO_PDU_ENDPOINT_HAKONIWA_CORE_SOURCE_DIR}/include/hakoniwa"
+      )
+    endif()
+  endif()
+  set(HAKO_ENDPOINT_CALLBACK_CORE_LIBS assets)
+  set(HAKO_ENDPOINT_POLLING_CORE_LIBS shakoc)
+else()
+  set(HAKO_ENDPOINT_VARIANT_CORE_ROOT "${HAKO_PDU_ENDPOINT_HAKONIWA_CORE_ROOT}")
+  if(HAKO_ENDPOINT_VARIANT_CORE_ROOT STREQUAL "")
+    if(DEFINED ENV{HAKONIWA_CORE_ROOT} AND NOT "$ENV{HAKONIWA_CORE_ROOT}" STREQUAL "")
+      set(HAKO_ENDPOINT_VARIANT_CORE_ROOT "$ENV{HAKONIWA_CORE_ROOT}")
+    elseif(WIN32)
+      set(HAKO_ENDPOINT_VARIANT_CORE_ROOT "${CMAKE_CURRENT_LIST_DIR}/../../../hakoniwa-core-pro/install")
+    else()
+      set(HAKO_ENDPOINT_VARIANT_CORE_ROOT "/usr/local/hakoniwa")
+    endif()
+  endif()
+
+  list(APPEND HAKO_ENDPOINT_VARIANT_CORE_INCLUDES
+    "${HAKO_ENDPOINT_VARIANT_CORE_ROOT}/include"
+    "${HAKO_ENDPOINT_VARIANT_CORE_ROOT}/include/hakoniwa"
+  )
+  if(UNIX AND NOT APPLE)
+    list(APPEND HAKO_ENDPOINT_VARIANT_CORE_INCLUDES /usr/include/hakoniwa)
+  endif()
+
+  set(HAKO_ENDPOINT_VARIANT_CORE_LIB_DIRS "${HAKO_ENDPOINT_VARIANT_CORE_ROOT}/lib")
+  if(UNIX AND NOT APPLE)
+    list(APPEND HAKO_ENDPOINT_VARIANT_CORE_LIB_DIRS /usr/lib/x86_64-linux-gnu)
+  endif()
+
+  find_library(HAKO_ENDPOINT_VARIANT_ASSETS_LIB NAMES assets PATHS ${HAKO_ENDPOINT_VARIANT_CORE_LIB_DIRS})
+  find_library(HAKO_ENDPOINT_VARIANT_SHAKOC_LIB NAMES shakoc PATHS ${HAKO_ENDPOINT_VARIANT_CORE_LIB_DIRS})
+
+  if(NOT HAKO_ENDPOINT_VARIANT_ASSETS_LIB)
+    message(FATAL_ERROR "Core callback endpoint variant requires the Hakoniwa assets library")
+  endif()
+  if(NOT HAKO_ENDPOINT_VARIANT_SHAKOC_LIB)
+    message(FATAL_ERROR "Core polling endpoint variant requires the Hakoniwa shakoc library")
+  endif()
+
+  set(HAKO_ENDPOINT_CALLBACK_CORE_LIBS ${HAKO_ENDPOINT_VARIANT_ASSETS_LIB})
+  set(HAKO_ENDPOINT_POLLING_CORE_LIBS ${HAKO_ENDPOINT_VARIANT_SHAKOC_LIB})
+
+  # assets is static on Windows and its hako dependency is not encoded in a raw
+  # find_library result, so retain the legacy Windows link requirement without
+  # pulling shakoc into the callback variant.
+  if(WIN32)
+    find_library(HAKO_ENDPOINT_VARIANT_HAKO_LIB NAMES hako PATHS ${HAKO_ENDPOINT_VARIANT_CORE_LIB_DIRS})
+    if(NOT HAKO_ENDPOINT_VARIANT_HAKO_LIB)
+      message(FATAL_ERROR "Core callback endpoint variant requires the Hakoniwa hako library on Windows")
+    endif()
+    list(APPEND HAKO_ENDPOINT_CALLBACK_CORE_LIBS ${HAKO_ENDPOINT_VARIANT_HAKO_LIB})
+  endif()
+endif()
+
+function(hako_configure_core_endpoint_variant target_name)
+  target_include_directories(${target_name}
+    PUBLIC
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/../../include>
+      $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+      ${HAKO_ENDPOINT_VARIANT_CORE_INCLUDES}
+  )
+
+  target_link_libraries(${target_name}
+    PUBLIC
+      nlohmann_json::nlohmann_json
+      ${HAKO_ENDPOINT_VARIANT_BOOST_TARGET}
+  )
+
+  target_compile_definitions(${target_name} PUBLIC HAKO_PDU_ENDPOINT_HAS_HAKONIWA_CORE=1)
+
+  if(WIN32)
+    target_link_libraries(${target_name} PRIVATE ws2_32)
+  endif()
+
+  if(MSVC)
+    target_compile_options(${target_name} PUBLIC /utf-8)
+    target_compile_options(${target_name} PRIVATE /bigobj)
+    target_compile_definitions(${target_name} PRIVATE _CRT_SECURE_NO_WARNINGS _WIN32_WINNT=0x0A00)
+  endif()
+
+  if(HAKO_PDU_ENDPOINT_ENABLE_ZENOH)
+    if(TARGET zenohc::lib)
+      target_link_libraries(${target_name} PUBLIC zenohc::lib)
+    elseif(TARGET zenohc)
+      target_link_libraries(${target_name} PUBLIC zenohc)
+    else()
+      message(FATAL_ERROR "Zenoh support enabled, but zenoh-c target was not found")
+    endif()
+    target_compile_definitions(${target_name} PUBLIC HAKO_PDU_ENDPOINT_HAS_ZENOH=1)
+  endif()
+
+  if(HAKO_PDU_ENDPOINT_ENABLE_MQTT)
+    if(TARGET PahoMqttCpp::paho-mqttpp3-static)
+      target_link_libraries(${target_name} PUBLIC PahoMqttCpp::paho-mqttpp3-static)
+    elseif(TARGET PahoMqttCpp::paho-mqttpp3)
+      target_link_libraries(${target_name} PUBLIC PahoMqttCpp::paho-mqttpp3)
+    elseif(TARGET paho-mqttpp3-static)
+      target_link_libraries(${target_name} PUBLIC paho-mqttpp3-static)
+    elseif(TARGET paho-mqttpp3)
+      target_link_libraries(${target_name} PUBLIC paho-mqttpp3)
+    else()
+      message(FATAL_ERROR "MQTT support enabled, but Paho MQTT C++ target was not found")
+    endif()
+    target_compile_definitions(${target_name} PUBLIC HAKO_PDU_ENDPOINT_HAS_MQTT=1)
+  endif()
+endfunction()
+
+add_library(hakoniwa_pdu_endpoint_core_callback
+  ${HAKO_ENDPOINT_VARIANT_COMMON_SRC}
+  ../comm_shm_callback.cpp
+  comm_shm_poll_unavailable.cpp
+  ../hakoniwa_time_source_callback.cpp
+  hakoniwa_time_source_poll_unavailable.cpp
+)
+hako_configure_core_endpoint_variant(hakoniwa_pdu_endpoint_core_callback)
+target_link_libraries(hakoniwa_pdu_endpoint_core_callback PUBLIC ${HAKO_ENDPOINT_CALLBACK_CORE_LIBS})
+add_library(hakoniwa_pdu_endpoint::core_callback ALIAS hakoniwa_pdu_endpoint_core_callback)
+
+add_library(hakoniwa_pdu_endpoint_core_polling
+  ${HAKO_ENDPOINT_VARIANT_COMMON_SRC}
+  ../comm_shm_poll.cpp
+  comm_shm_callback_unavailable.cpp
+  ../hakoniwa_time_source_poll.cpp
+  hakoniwa_time_source_callback_unavailable.cpp
+)
+hako_configure_core_endpoint_variant(hakoniwa_pdu_endpoint_core_polling)
+target_link_libraries(hakoniwa_pdu_endpoint_core_polling PUBLIC ${HAKO_ENDPOINT_POLLING_CORE_LIBS})
+add_library(hakoniwa_pdu_endpoint::core_polling ALIAS hakoniwa_pdu_endpoint_core_polling)
+
+message(STATUS "Hakoniwa Core endpoint variants enabled: core_callback, core_polling")

--- a/src/core_variants/comm_shm_callback_unavailable.cpp
+++ b/src/core_variants/comm_shm_callback_unavailable.cpp
@@ -1,0 +1,56 @@
+#include "hakoniwa/pdu/comm/comm_shm_impl.hpp"
+
+namespace hakoniwa {
+namespace pdu {
+namespace comm {
+
+PduCommShmCallbackImpl::PduCommShmCallbackImpl(std::shared_ptr<PduDefinition> pdu_def,
+    std::optional<std::string> io_asset_name,
+    std::optional<std::string> pdu_config_path)
+    : pdu_def_(std::move(pdu_def)),
+      io_asset_name_(std::move(io_asset_name)),
+      pdu_config_path_(std::move(pdu_config_path))
+{
+}
+
+PduCommShmCallbackImpl::~PduCommShmCallbackImpl() = default;
+
+HakoPduErrorType PduCommShmCallbackImpl::ensure_attached() noexcept
+{
+    return HAKO_PDU_ERR_UNSUPPORTED;
+}
+
+HakoPduErrorType PduCommShmCallbackImpl::create_pdu_lchannel(const std::string&, HakoPduChannelIdType, size_t) noexcept
+{
+    return HAKO_PDU_ERR_UNSUPPORTED;
+}
+
+HakoPduErrorType PduCommShmCallbackImpl::send(const PduResolvedKey&, std::span<const std::byte>) noexcept
+{
+    return HAKO_PDU_ERR_UNSUPPORTED;
+}
+
+HakoPduErrorType PduCommShmCallbackImpl::recv(const PduResolvedKey&, std::span<std::byte>, size_t&) noexcept
+{
+    return HAKO_PDU_ERR_UNSUPPORTED;
+}
+
+HakoPduErrorType PduCommShmCallbackImpl::register_rcv_event(const PduResolvedKey&, void (*)(int), int&) noexcept
+{
+    return HAKO_PDU_ERR_UNSUPPORTED;
+}
+
+HakoPduErrorType PduCommShmCallbackImpl::attach_asset_context(
+    const std::optional<std::string>&,
+    const std::optional<std::string>&) noexcept
+{
+    return HAKO_PDU_ERR_UNSUPPORTED;
+}
+
+void PduCommShmCallbackImpl::process_recv_events() noexcept
+{
+}
+
+} // namespace comm
+} // namespace pdu
+} // namespace hakoniwa

--- a/src/core_variants/comm_shm_poll_unavailable.cpp
+++ b/src/core_variants/comm_shm_poll_unavailable.cpp
@@ -1,0 +1,40 @@
+#include "hakoniwa/pdu/comm/comm_shm_impl.hpp"
+
+namespace hakoniwa {
+namespace pdu {
+namespace comm {
+
+PduCommShmPollImpl::PduCommShmPollImpl(std::shared_ptr<PduDefinition> pdu_def, const std::string& asset_name)
+    : pdu_def_(std::move(pdu_def)), asset_name_(asset_name)
+{
+}
+
+PduCommShmPollImpl::~PduCommShmPollImpl() = default;
+
+HakoPduErrorType PduCommShmPollImpl::create_pdu_lchannel(const std::string&, HakoPduChannelIdType, size_t) noexcept
+{
+    return HAKO_PDU_ERR_UNSUPPORTED;
+}
+
+HakoPduErrorType PduCommShmPollImpl::send(const PduResolvedKey&, std::span<const std::byte>) noexcept
+{
+    return HAKO_PDU_ERR_UNSUPPORTED;
+}
+
+HakoPduErrorType PduCommShmPollImpl::recv(const PduResolvedKey&, std::span<std::byte>, size_t&) noexcept
+{
+    return HAKO_PDU_ERR_UNSUPPORTED;
+}
+
+HakoPduErrorType PduCommShmPollImpl::register_rcv_event(const PduResolvedKey&, void (*)(int), int&) noexcept
+{
+    return HAKO_PDU_ERR_UNSUPPORTED;
+}
+
+void PduCommShmPollImpl::process_recv_events() noexcept
+{
+}
+
+} // namespace comm
+} // namespace pdu
+} // namespace hakoniwa

--- a/src/core_variants/hakoniwa_time_source_callback_unavailable.cpp
+++ b/src/core_variants/hakoniwa_time_source_callback_unavailable.cpp
@@ -1,0 +1,14 @@
+#include "hakoniwa/time_source/hakoniwa_time_source_impl.hpp"
+
+namespace hakoniwa::time_source {
+
+uint64_t HakoniwaTimeSourceCallbackImpl::get_microseconds() const
+{
+    return 0;
+}
+
+void HakoniwaTimeSourceCallbackImpl::advance_time(uint64_t)
+{
+}
+
+} // namespace hakoniwa::time_source

--- a/src/core_variants/hakoniwa_time_source_poll_unavailable.cpp
+++ b/src/core_variants/hakoniwa_time_source_poll_unavailable.cpp
@@ -1,0 +1,14 @@
+#include "hakoniwa/time_source/hakoniwa_time_source_impl.hpp"
+
+namespace hakoniwa::time_source {
+
+uint64_t HakoniwaTimeSourcePollImpl::get_microseconds() const
+{
+    return 0;
+}
+
+void HakoniwaTimeSourcePollImpl::advance_time(uint64_t)
+{
+}
+
+} // namespace hakoniwa::time_source


### PR DESCRIPTION
## Summary

Add two new Hakoniwa Core-aware endpoint library targets while leaving the existing `hakoniwa_pdu_endpoint` target unchanged:

- `hakoniwa_pdu_endpoint_core_callback` / `hakoniwa_pdu_endpoint::core_callback`
  - uses the callback SHM/time-source implementation
  - links the Hakoniwa `assets` frontend
- `hakoniwa_pdu_endpoint_core_polling` / `hakoniwa_pdu_endpoint::core_polling`
  - uses the polling SHM/time-source implementation
  - links the Hakoniwa `shakoc` frontend

The variants are generated only when `HAKO_PDU_ENDPOINT_ENABLE_HAKONIWA_CORE=ON`. Core-disabled builds follow the existing path unchanged.

## Why

`assets` and `shakoc` are alternative Hakoniwa Core frontends. The legacy endpoint Core integration links both for compatibility, which is risky for new integrations and makes the actual Core API dependency ambiguous.

This PR adds explicit variants beside the legacy target instead of changing its behavior. That gives new consumers a migration path with no required change for existing users.

The intended next consumer is `hakoniwa-pdu-bridge-core`, whose Hakoniwa callback asset should use the new `core_callback` variant.

## Compatibility

- Existing `hakoniwa_pdu_endpoint` target: unchanged.
- Existing runtime SHM `impl_type` behavior on the legacy target: unchanged.
- Manifest semantics remain Core enabled/disabled; no callback/polling selection is added to the manifest.
- Install/export behavior for the new targets is intentionally deferred until the variants are validated against `hakoniwa-core-pro`.

## Validation plan

1. Existing Core-OFF CI should remain unchanged.
2. Validate both new targets against an installed/source `hakoniwa-core-pro` build on Ubuntu.
3. Then add macOS and Windows Core-ON validation before switching Bridge Core to `core_callback`.
