### PR TITLE
Validate Hakoniwa Core endpoint variants on macOS and Windows

### DIFF
--- a/.github/workflows/core-variants.yml
+++ b/.github/workflows/core-variants.yml
@@ -5,6 +5,48 @@ on:
   pull_request:
 
 jobs:
+  ubuntu-core-variants:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout endpoint
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y g++-12 cmake libboost-dev
+          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-12 12
+
+      - name: Build and install hakoniwa-core-pro
+        run: |
+          git clone --recursive https://github.com/hakoniwalab/hakoniwa-core-pro.git
+          cmake -S hakoniwa-core-pro -B hakoniwa-core-pro/build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX="${GITHUB_WORKSPACE}/core-install" \
+            -DHAKO_CORE_PRO_BUILD_COMMAND=OFF \
+            -DHAKO_CORE_PRO_BUILD_EXAMPLES=OFF \
+            -DHAKO_CORE_PRO_BUILD_PYTHON_BINDINGS=OFF \
+            -DHAKO_ENABLE_GTEST=OFF
+          cmake --build hakoniwa-core-pro/build --config Release
+          cmake --install hakoniwa-core-pro/build --config Release --prefix "${GITHUB_WORKSPACE}/core-install"
+
+      - name: Configure endpoint with Hakoniwa Core
+        run: |
+          cmake -S . -B build-core-variants \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DHAKO_PDU_ENDPOINT_ENABLE_HAKONIWA_CORE=ON \
+            -DHAKO_PDU_ENDPOINT_HAKONIWA_CORE_ROOT="${GITHUB_WORKSPACE}/core-install" \
+            -DHAKO_PDU_ENDPOINT_BUILD_TESTS=OFF \
+            -DHAKO_PDU_ENDPOINT_BUILD_EXAMPLES=OFF \
+            -DHAKO_PDU_ENDPOINT_BUILD_TOOLS=OFF \
+            -DHAKO_PDU_ENDPOINT_BUILD_BENCHMARKS=OFF \
+            -DHAKO_PDU_ENDPOINT_INSTALL=OFF
+
+      - name: Build callback and polling variants
+        run: |
+          cmake --build build-core-variants --config Release --target hakoniwa_pdu_endpoint_core_callback
+          cmake --build build-core-variants --config Release --target hakoniwa_pdu_endpoint_core_polling
+
   macos-core-variants:
     runs-on: macos-latest
     steps:
@@ -27,7 +69,7 @@ jobs:
             -DHAKO_CORE_PRO_BUILD_PYTHON_BINDINGS=OFF \
             -DHAKO_ENABLE_GTEST=OFF
           cmake --build hakoniwa-core-pro/build --config Release
-          sudo cmake --install hakoniwa-core-pro/build --config Release --prefix "${GITHUB_WORKSPACE}/core-install"
+          cmake --install hakoniwa-core-pro/build --config Release --prefix "${GITHUB_WORKSPACE}/core-install"
 
       - name: Configure endpoint with Hakoniwa Core
         run: |

--- a/.github/workflows/core-variants.yml
+++ b/.github/workflows/core-variants.yml
@@ -107,7 +107,9 @@ jobs:
         shell: pwsh
         run: |
           git clone --recursive https://github.com/hakoniwalab/hakoniwa-core-pro.git
+          $coreOptions = "$env:GITHUB_WORKSPACE/hakoniwa-core-pro/cmake-options/win-cmake-options.cmake"
           cmake -S hakoniwa-core-pro -B hakoniwa-core-pro/build -A x64 `
+            -DHAKO_CLIENT_OPTION_FILEPATH="$coreOptions" `
             -DCMAKE_INSTALL_PREFIX="$env:GITHUB_WORKSPACE/core-install" `
             -DHAKO_CORE_CONFIG_INSTALL_DIR=etc/hakoniwa `
             -DHAKO_CORE_PRO_BUILD_COMMAND=OFF `

--- a/.github/workflows/core-variants.yml
+++ b/.github/workflows/core-variants.yml
@@ -23,6 +23,7 @@ jobs:
           cmake -S hakoniwa-core-pro -B hakoniwa-core-pro/build \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_INSTALL_PREFIX="${GITHUB_WORKSPACE}/core-install" \
+            -DHAKO_CORE_CONFIG_INSTALL_DIR=etc/hakoniwa \
             -DHAKO_CORE_PRO_BUILD_COMMAND=OFF \
             -DHAKO_CORE_PRO_BUILD_EXAMPLES=OFF \
             -DHAKO_CORE_PRO_BUILD_PYTHON_BINDINGS=OFF \
@@ -64,12 +65,13 @@ jobs:
           cmake -S hakoniwa-core-pro -B hakoniwa-core-pro/build \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_INSTALL_PREFIX="${GITHUB_WORKSPACE}/core-install" \
+            -DHAKO_CORE_CONFIG_INSTALL_DIR=etc/hakoniwa \
             -DHAKO_CORE_PRO_BUILD_COMMAND=OFF \
             -DHAKO_CORE_PRO_BUILD_EXAMPLES=OFF \
             -DHAKO_CORE_PRO_BUILD_PYTHON_BINDINGS=OFF \
             -DHAKO_ENABLE_GTEST=OFF
           cmake --build hakoniwa-core-pro/build --config Release
-          sudo cmake --install hakoniwa-core-pro/build --config Release --prefix "${GITHUB_WORKSPACE}/core-install"
+          cmake --install hakoniwa-core-pro/build --config Release --prefix "${GITHUB_WORKSPACE}/core-install"
 
       - name: Configure endpoint with Hakoniwa Core
         run: |
@@ -107,6 +109,7 @@ jobs:
           git clone --recursive https://github.com/hakoniwalab/hakoniwa-core-pro.git
           cmake -S hakoniwa-core-pro -B hakoniwa-core-pro/build -A x64 `
             -DCMAKE_INSTALL_PREFIX="$env:GITHUB_WORKSPACE/core-install" `
+            -DHAKO_CORE_CONFIG_INSTALL_DIR=etc/hakoniwa `
             -DHAKO_CORE_PRO_BUILD_COMMAND=OFF `
             -DHAKO_CORE_PRO_BUILD_EXAMPLES=OFF `
             -DHAKO_CORE_PRO_BUILD_PYTHON_BINDINGS=OFF `

--- a/.github/workflows/core-variants.yml
+++ b/.github/workflows/core-variants.yml
@@ -1,0 +1,93 @@
+name: core-variants
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  macos-core-variants:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout endpoint
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          brew update
+          brew install cmake boost
+
+      - name: Build and install hakoniwa-core-pro
+        run: |
+          git clone --recursive https://github.com/hakoniwalab/hakoniwa-core-pro.git
+          cmake -S hakoniwa-core-pro -B hakoniwa-core-pro/build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX="${GITHUB_WORKSPACE}/core-install" \
+            -DHAKO_CORE_PRO_BUILD_COMMAND=OFF \
+            -DHAKO_CORE_PRO_BUILD_EXAMPLES=OFF \
+            -DHAKO_CORE_PRO_BUILD_PYTHON_BINDINGS=OFF \
+            -DHAKO_ENABLE_GTEST=OFF
+          cmake --build hakoniwa-core-pro/build --config Release
+          sudo cmake --install hakoniwa-core-pro/build --config Release --prefix "${GITHUB_WORKSPACE}/core-install"
+
+      - name: Configure endpoint with Hakoniwa Core
+        run: |
+          cmake -S . -B build-core-variants \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DHAKO_PDU_ENDPOINT_ENABLE_HAKONIWA_CORE=ON \
+            -DHAKO_PDU_ENDPOINT_HAKONIWA_CORE_ROOT="${GITHUB_WORKSPACE}/core-install" \
+            -DHAKO_PDU_ENDPOINT_BUILD_TESTS=OFF \
+            -DHAKO_PDU_ENDPOINT_BUILD_EXAMPLES=OFF \
+            -DHAKO_PDU_ENDPOINT_BUILD_TOOLS=OFF \
+            -DHAKO_PDU_ENDPOINT_BUILD_BENCHMARKS=OFF \
+            -DHAKO_PDU_ENDPOINT_INSTALL=OFF
+
+      - name: Build callback and polling variants
+        run: |
+          cmake --build build-core-variants --config Release --target hakoniwa_pdu_endpoint_core_callback
+          cmake --build build-core-variants --config Release --target hakoniwa_pdu_endpoint_core_polling
+
+  windows-core-variants:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout endpoint
+        uses: actions/checkout@v4
+
+      - name: Install vcpkg and Boost headers
+        shell: pwsh
+        run: |
+          git clone https://github.com/microsoft/vcpkg.git C:\vcpkg
+          & C:\vcpkg\bootstrap-vcpkg.bat
+          & C:\vcpkg\vcpkg.exe install boost-asio:x64-windows boost-beast:x64-windows
+
+      - name: Build and install hakoniwa-core-pro
+        shell: pwsh
+        run: |
+          git clone --recursive https://github.com/hakoniwalab/hakoniwa-core-pro.git
+          cmake -S hakoniwa-core-pro -B hakoniwa-core-pro/build -A x64 `
+            -DCMAKE_INSTALL_PREFIX="$env:GITHUB_WORKSPACE/core-install" `
+            -DHAKO_CORE_PRO_BUILD_COMMAND=OFF `
+            -DHAKO_CORE_PRO_BUILD_EXAMPLES=OFF `
+            -DHAKO_CORE_PRO_BUILD_PYTHON_BINDINGS=OFF `
+            -DHAKO_ENABLE_GTEST=OFF
+          cmake --build hakoniwa-core-pro/build --config Release
+          cmake --install hakoniwa-core-pro/build --config Release --prefix "$env:GITHUB_WORKSPACE/core-install"
+
+      - name: Configure endpoint with Hakoniwa Core
+        shell: pwsh
+        run: |
+          cmake -S . -B build-core-variants -A x64 `
+            -DCMAKE_TOOLCHAIN_FILE=C:\vcpkg\scripts\buildsystems\vcpkg.cmake `
+            -DVCPKG_TARGET_TRIPLET=x64-windows `
+            -DHAKO_PDU_ENDPOINT_ENABLE_HAKONIWA_CORE=ON `
+            -DHAKO_PDU_ENDPOINT_HAKONIWA_CORE_ROOT="$env:GITHUB_WORKSPACE/core-install" `
+            -DHAKO_PDU_ENDPOINT_BUILD_TESTS=OFF `
+            -DHAKO_PDU_ENDPOINT_BUILD_EXAMPLES=OFF `
+            -DHAKO_PDU_ENDPOINT_BUILD_TOOLS=OFF `
+            -DHAKO_PDU_ENDPOINT_BUILD_BENCHMARKS=OFF `
+            -DHAKO_PDU_ENDPOINT_INSTALL=OFF
+
+      - name: Build callback and polling variants
+        shell: pwsh
+        run: |
+          cmake --build build-core-variants --config Release --target hakoniwa_pdu_endpoint_core_callback
+          cmake --build build-core-variants --config Release --target hakoniwa_pdu_endpoint_core_polling

--- a/.github/workflows/core-variants.yml
+++ b/.github/workflows/core-variants.yml
@@ -69,7 +69,7 @@ jobs:
             -DHAKO_CORE_PRO_BUILD_PYTHON_BINDINGS=OFF \
             -DHAKO_ENABLE_GTEST=OFF
           cmake --build hakoniwa-core-pro/build --config Release
-          cmake --install hakoniwa-core-pro/build --config Release --prefix "${GITHUB_WORKSPACE}/core-install"
+          sudo cmake --install hakoniwa-core-pro/build --config Release --prefix "${GITHUB_WORKSPACE}/core-install"
 
       - name: Configure endpoint with Hakoniwa Core
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,9 +25,6 @@ include(CMakePackageConfigHelpers)
 
 # add_subdirectory を使って src と test ディレクトリの CMakeLists.txt を含める
 add_subdirectory(src)
-if(HAKO_PDU_ENDPOINT_ENABLE_HAKONIWA_CORE)
-  add_subdirectory(src/core_variants)
-endif()
 option(HAKO_PDU_ENDPOINT_BUILD_TOOLS "Build debug and inspection tools" ON)
 if(HAKO_PDU_ENDPOINT_BUILD_TOOLS)
   add_subdirectory(tools)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,9 @@ include(CMakePackageConfigHelpers)
 
 # add_subdirectory を使って src と test ディレクトリの CMakeLists.txt を含める
 add_subdirectory(src)
+if(HAKO_PDU_ENDPOINT_ENABLE_HAKONIWA_CORE)
+  add_subdirectory(src/core_variants)
+endif()
 option(HAKO_PDU_ENDPOINT_BUILD_TOOLS "Build debug and inspection tools" ON)
 if(HAKO_PDU_ENDPOINT_BUILD_TOOLS)
   add_subdirectory(tools)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -296,6 +296,11 @@ if(HAKO_PDU_ENDPOINT_ENABLE_HAKONIWA_CORE)
       message(WARNING "Hakoniwa core include directory not found: ${HAKO_HAKONIWA_CORE_ROOT}/include")
     endif()
   endif()
+
+  # Core-aware variants must be configured below the dependency resolution above
+  # so directory-scoped imported targets (for example nlohmann_json) and resolved
+  # dependency variables are visible to the variant subdirectory.
+  add_subdirectory(core_variants)
 endif()
 
 option(HAKO_PDU_ENDPOINT_BUILD_TESTS "Build UDP endpoint tests" ON)


### PR DESCRIPTION
## Summary

Add a dedicated `core-variants` GitHub Actions workflow that validates the new Hakoniwa Core-aware endpoint library variants on macOS and Windows.

The workflow intentionally leaves the existing `ci.yml` unchanged.

## Validation

For each OS, the workflow:

1. builds `hakoniwa-core-pro` from source with nonessential commands/examples/python/tests disabled;
2. installs Core into a local CI prefix;
3. configures `hakoniwa-pdu-endpoint` with `HAKO_PDU_ENDPOINT_ENABLE_HAKONIWA_CORE=ON`;
4. explicitly builds:
   - `hakoniwa_pdu_endpoint_core_callback`
   - `hakoniwa_pdu_endpoint_core_polling`

Windows also installs Boost.Asio/Beast through vcpkg and keeps the Core build on the existing static-library path.

## Scope

This PR proves cross-platform build compatibility of the two new variants. Runtime/link smoke tests can be added separately after the platform-specific build paths are stable.
