### PR TITLE
Fix invalid Linux Core include in installed Endpoint package

### DIFF
--- a/cmake/hakoniwa_pdu_endpointConfig.cmake.in
+++ b/cmake/hakoniwa_pdu_endpointConfig.cmake.in
@@ -26,3 +26,20 @@ if(@HAKO_PDU_ENDPOINT_PACKAGE_HAS_HAKONIWA_CORE@)
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/hakoniwa_pdu_endpointTargets.cmake")
+
+# Older Core-enabled Endpoint exports may carry the historical Linux fallback
+# /usr/include/hakoniwa in their public include interface even when that path
+# does not exist. Imported targets treat a missing interface include directory
+# as a configure-time error in downstream consumers. Keep the fallback only on
+# hosts where it is actually present; normal installed Core headers are already
+# provided through the package prefix / hakoniwa-core dependency.
+if(TARGET hakoniwa_pdu_endpoint::hakoniwa_pdu_endpoint
+   AND NOT EXISTS "/usr/include/hakoniwa")
+  get_target_property(_hakoniwa_endpoint_includes
+    hakoniwa_pdu_endpoint::hakoniwa_pdu_endpoint INTERFACE_INCLUDE_DIRECTORIES)
+  if(_hakoniwa_endpoint_includes)
+    list(REMOVE_ITEM _hakoniwa_endpoint_includes "/usr/include/hakoniwa")
+    set_target_properties(hakoniwa_pdu_endpoint::hakoniwa_pdu_endpoint PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "${_hakoniwa_endpoint_includes}")
+  endif()
+endif()


### PR DESCRIPTION
## Summary

Fix a downstream CMake package-consumer failure exposed by `hakoniwa-pdu-bridge-core` package-contract CI on GNU/Linux.

The installed `hakoniwa_pdu_endpoint::hakoniwa_pdu_endpoint` target can carry the historical fallback `/usr/include/hakoniwa` in `INTERFACE_INCLUDE_DIRECTORIES` even when that directory does not exist. CMake treats a missing include directory on an imported target as a configure-time error in consumers.

## Change

When loading the installed Endpoint package, remove `/usr/include/hakoniwa` from the imported target interface only when the path is absent. Existing systems that actually provide that legacy include path are left unchanged.

## Why

Modern Core-enabled consumers should get Hakoniwa Core headers from the configured install prefix / `hakoniwa-core` package dependency, not from a nonexistent global fallback.

This was reproduced by Bridge PR #24 on both Ubuntu x64 and Linux ARM64; macOS and Windows were unaffected.