### PR TITLE
Prevent SIGPIPE on POSIX socket writes

### DIFF
--- a/src/socket_portability_posix.cpp
+++ b/src/socket_portability_posix.cpp
@@ -83,12 +83,26 @@ HakoPduErrorType set_socket_nonblocking(SocketHandle fd, bool enabled) noexcept
 
 SocketHandle create_socket(int family, int type, int protocol) noexcept
 {
-    return ::socket(family, type, protocol);
+    SocketHandle fd = ::socket(family, type, protocol);
+#if defined(SO_NOSIGPIPE)
+    if (is_valid_socket(fd)) {
+        const int enabled = 1;
+        (void)::setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, &enabled, sizeof(enabled));
+    }
+#endif
+    return fd;
 }
 
 SocketHandle accept_socket(SocketHandle fd, SocketAddress* address, SocketLength* address_len) noexcept
 {
-    return ::accept(fd, address, address_len);
+    SocketHandle accepted_fd = ::accept(fd, address, address_len);
+#if defined(SO_NOSIGPIPE)
+    if (is_valid_socket(accepted_fd)) {
+        const int enabled = 1;
+        (void)::setsockopt(accepted_fd, SOL_SOCKET, SO_NOSIGPIPE, &enabled, sizeof(enabled));
+    }
+#endif
+    return accepted_fd;
 }
 
 int connect_socket(SocketHandle fd, const SocketAddress* address, SocketLength address_len) noexcept
@@ -113,6 +127,9 @@ SocketSize recv_socket(SocketHandle fd, std::byte* buffer, size_t size, int flag
 
 SocketSize send_socket(SocketHandle fd, const std::byte* buffer, size_t size, int flags) noexcept
 {
+#if defined(MSG_NOSIGNAL)
+    flags |= MSG_NOSIGNAL;
+#endif
     return ::send(fd, buffer, size, flags);
 }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -54,4 +54,18 @@ target_link_libraries(cache_runtime_config_test
 
 add_test(NAME cache_runtime_config_test COMMAND cache_runtime_config_test)
 
+if(NOT WIN32)
+  add_executable(socket_portability_test
+    socket_portability_test.cpp
+  )
+
+  target_link_libraries(socket_portability_test
+    PRIVATE
+      hakoniwa_pdu_endpoint
+      GTest::gtest_main
+  )
+
+  add_test(NAME socket_portability_test COMMAND socket_portability_test)
+endif()
+
 set_tests_properties(endpoint_test PROPERTIES WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}")

--- a/test/socket_portability_test.cpp
+++ b/test/socket_portability_test.cpp
@@ -1,0 +1,50 @@
+#include "hakoniwa/pdu/socket_portability.hpp"
+
+#include <gtest/gtest.h>
+
+#ifndef _WIN32
+#include <cerrno>
+#include <sys/socket.h>
+#include <unistd.h>
+#endif
+
+using namespace hakoniwa::pdu;
+
+#ifndef _WIN32
+
+TEST(SocketPortabilityTest, CreatedSocketDisablesSigpipeWhenSupported)
+{
+#if defined(SO_NOSIGPIPE)
+    const SocketHandle fd = create_socket(AF_INET, SOCK_STREAM, 0);
+    ASSERT_TRUE(is_valid_socket(fd));
+
+    int enabled = 0;
+    ASSERT_EQ(get_socket_option_int(fd, SOL_SOCKET, SO_NOSIGPIPE, enabled), HAKO_PDU_ERR_OK);
+    EXPECT_EQ(enabled, 1);
+
+    EXPECT_EQ(close_socket(fd), HAKO_PDU_ERR_OK);
+#else
+    GTEST_SKIP() << "SO_NOSIGPIPE is not available on this platform";
+#endif
+}
+
+TEST(SocketPortabilityTest, SendReturnsErrorInsteadOfRaisingSigpipe)
+{
+#if defined(MSG_NOSIGNAL)
+    int fds[2] = {-1, -1};
+    ASSERT_EQ(::socketpair(AF_UNIX, SOCK_STREAM, 0, fds), 0);
+    ASSERT_EQ(::close(fds[1]), 0);
+
+    const std::byte payload{0x01};
+    errno = 0;
+    const SocketSize sent = send_socket(fds[0], &payload, 1, 0);
+
+    EXPECT_EQ(sent, static_cast<SocketSize>(-1));
+    EXPECT_EQ(errno, EPIPE);
+    EXPECT_EQ(close_socket(fds[0]), HAKO_PDU_ERR_OK);
+#else
+    GTEST_SKIP() << "MSG_NOSIGNAL is not available on this platform";
+#endif
+}
+
+#endif


### PR DESCRIPTION
## Summary

Prevent POSIX processes from being terminated by `SIGPIPE` when a TCP peer disconnects while Endpoint is writing.

This was found while running the `hakoniwa-conductor-light` WSL2/Ubuntu verification matrix: build succeeded, but `rpc_server_transport_test` terminated with `SIGPIPE` during disconnect/reconnect and max-client scenarios.

## Changes

- use `MSG_NOSIGNAL` in the POSIX `send_socket()` wrapper when the platform provides it
- set `SO_NOSIGPIPE` on created and accepted sockets when the platform provides that socket option (notably Apple platforms)
- keep the behavior inside the socket portability layer rather than changing individual TCP/TCP-mux callers or globally ignoring `SIGPIPE`
- add POSIX regression tests
  - Linux-style `MSG_NOSIGNAL`: writing to a closed peer returns `EPIPE` instead of terminating the process
  - Apple-style `SO_NOSIGPIPE`: sockets created by the portability layer have the option enabled

## Rationale

Both `TcpComm` and `TcpCommMultiplexer` route writes through `send_socket()`, so fixing the portability layer protects all Endpoint TCP users consistently.

A process-wide `signal(SIGPIPE, SIG_IGN)` is intentionally avoided because Endpoint is a library and should not modify the signal disposition of its host process.

## Manual verification requested

After updating the Conductor Light endpoint submodule to this branch/commit on WSL2 Ubuntu:

```bash
python tools/hako.py build
python tools/hako.py test
python tools/hako.py smoke auto
python tools/hako.py smoke manual
```

Expected: `rpc_server_transport_test` no longer terminates with `SIGPIPE`.