### PR TITLE
Treat Winsock socket timeouts as retryable

### DIFF
--- a/src/socket_portability_win.cpp
+++ b/src/socket_portability_win.cpp
@@ -70,7 +70,11 @@ std::string socket_error_message(int error_number)
 
 bool is_socket_would_block(int error_number) noexcept
 {
-    return error_number == WSAEWOULDBLOCK;
+    // POSIX reports SO_RCVTIMEO/SO_SNDTIMEO expiry as EAGAIN/EWOULDBLOCK,
+    // while Winsock reports the equivalent blocking-socket timeout as WSAETIMEDOUT.
+    // Normalize both cases as retryable so higher-level TCP/TCP-mux/UDP loops behave
+    // consistently across platforms.
+    return error_number == WSAEWOULDBLOCK || error_number == WSAETIMEDOUT;
 }
 
 bool is_socket_interrupted(int error_number) noexcept

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -54,18 +54,16 @@ target_link_libraries(cache_runtime_config_test
 
 add_test(NAME cache_runtime_config_test COMMAND cache_runtime_config_test)
 
-if(NOT WIN32)
-  add_executable(socket_portability_test
-    socket_portability_test.cpp
-  )
+add_executable(socket_portability_test
+  socket_portability_test.cpp
+)
 
-  target_link_libraries(socket_portability_test
-    PRIVATE
-      hakoniwa_pdu_endpoint
-      GTest::gtest_main
-  )
+target_link_libraries(socket_portability_test
+  PRIVATE
+    hakoniwa_pdu_endpoint
+    GTest::gtest_main
+)
 
-  add_test(NAME socket_portability_test COMMAND socket_portability_test)
-endif()
+add_test(NAME socket_portability_test COMMAND socket_portability_test)
 
 set_tests_properties(endpoint_test PROPERTIES WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}")

--- a/test/socket_portability_test.cpp
+++ b/test/socket_portability_test.cpp
@@ -10,7 +10,16 @@
 
 using namespace hakoniwa::pdu;
 
-#ifndef _WIN32
+#ifdef _WIN32
+
+TEST(SocketPortabilityTest, WindowsTimeoutIsRetryableLikeWouldBlock)
+{
+    EXPECT_TRUE(is_socket_would_block(WSAEWOULDBLOCK));
+    EXPECT_TRUE(is_socket_would_block(WSAETIMEDOUT));
+    EXPECT_FALSE(is_socket_would_block(WSAECONNRESET));
+}
+
+#else
 
 TEST(SocketPortabilityTest, CreatedSocketDisablesSigpipeWhenSupported)
 {


### PR DESCRIPTION
## Summary

Fix Windows RPC disconnect/reconnect churn caused by Winsock timeout semantics.

This was found while validating `hakoniwa-conductor-light` on native Windows. Its RPC tests repeatedly created server slots, timed out, and eventually failed because Endpoint treated a normal blocking-socket receive timeout as an I/O disconnect.

## Root cause

Endpoint configures `SO_RCVTIMEO` / `SO_SNDTIMEO` on TCP, TCP Mux, and UDP sockets.

On POSIX, an expired socket timeout is surfaced as `EAGAIN` / `EWOULDBLOCK`, which Endpoint already treats as retryable through `is_socket_would_block()`.

On Winsock, the equivalent blocking-socket timeout is `WSAETIMEDOUT`. The Windows portability layer previously recognized only `WSAEWOULDBLOCK`, so `WSAETIMEDOUT` fell through to `HAKO_PDU_ERR_IO_ERROR` and was interpreted as a disconnect.

## Changes

- normalize `WSAETIMEDOUT` as retryable in the Windows `is_socket_would_block()` portability mapping
- document why this intentionally matches POSIX timeout behavior
- run `socket_portability_test` on Windows as well as POSIX
- add Windows regression coverage for:
  - `WSAEWOULDBLOCK` -> retryable
  - `WSAETIMEDOUT` -> retryable
  - `WSAECONNRESET` -> not retryable

Because TCP, TCP Mux, and UDP already route their retry decisions through `is_socket_would_block()`, the fix applies consistently without platform checks in each transport.

## Manual verification requested

After updating the Endpoint submodule in `hakoniwa-conductor-light` to this branch/commit on Windows:

```powershell
python tools/hako.py build
python tools/hako.py test
python tools/hako.py smoke auto
python tools/hako.py smoke manual
```

Expected: the RPC tests no longer cycle through repeated `TCP Comm read header failed: 3` / reconnect slots, and all Conductor Light tests proceed normally.

No CI workflow is added by this PR.