### PR TITLE
ci: reproduce Windows Core build through hako.py

### DIFF
--- a/.github/workflows/hako-core-integration.yml
+++ b/.github/workflows/hako-core-integration.yml
@@ -70,7 +70,25 @@ jobs:
         run: python tools/hako.py configure
 
       # This is the regression/reproduction point from hakoniwa-business-pack#47.
-      # Before the upstream package/export issue is fixed, the Core callback/polling
-      # variants are expected to expose the missing-header failure here.
+      # Capture the complete output so follow-up diagnosis is based on the actual
+      # latest-Core failure rather than the older candidate's inferred root cause.
       - name: Build through hako.py
-        run: python tools/hako.py build --config Release
+        shell: pwsh
+        run: |
+          python tools/hako.py build --config Release 2>&1 | Tee-Object -FilePath hako-build.log
+          $exitCode = $LASTEXITCODE
+          if ($exitCode -ne 0) {
+            Write-Host "=== hako.py build error summary ==="
+            Select-String -Path hako-build.log -Pattern 'error C[0-9]+|fatal error|No such file|LNK[0-9]+' |
+              Select-Object -Last 80 |
+              ForEach-Object { $_.Line }
+            exit $exitCode
+          }
+
+      - name: Upload hako.py build log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-hako-core-build-log
+          path: hako-build.log
+          if-no-files-found: warn

--- a/.github/workflows/hako-core-integration.yml
+++ b/.github/workflows/hako-core-integration.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Build through hako.py
         shell: pwsh
         run: |
-          python tools/hako.py build --config Release 2>&1 | Tee-Object -FilePath hako-build.log
+          python tools/hako.py build 2>&1 | Tee-Object -FilePath hako-build.log
           $exitCode = $LASTEXITCODE
           if ($exitCode -ne 0) {
             Write-Host "=== hako.py build error summary ==="

--- a/.github/workflows/hako-core-integration.yml
+++ b/.github/workflows/hako-core-integration.yml
@@ -1,0 +1,76 @@
+name: hako-core-integration
+
+on:
+  push:
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - "LICENSE*"
+  pull_request:
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - "LICENSE*"
+
+jobs:
+  windows-hako-core:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout endpoint
+        uses: actions/checkout@v4
+
+      - name: Setup Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Python build prerequisites
+        run: python -m pip install --upgrade pip setuptools cffi
+
+      - name: Install vcpkg and Boost headers
+        shell: pwsh
+        run: |
+          git clone https://github.com/microsoft/vcpkg.git C:\vcpkg
+          & C:\vcpkg\bootstrap-vcpkg.bat
+          & C:\vcpkg\vcpkg.exe install boost-asio:x64-windows boost-beast:x64-windows
+
+      # Intentionally consume the current Core main branch. This is an integration
+      # early-warning check, not a released-version compatibility matrix.
+      - name: Build and install latest hakoniwa-core-pro
+        shell: pwsh
+        run: |
+          git clone --recursive https://github.com/hakoniwalab/hakoniwa-core-pro.git
+          $coreOptions = "$env:GITHUB_WORKSPACE/hakoniwa-core-pro/cmake-options/win-cmake-options.cmake"
+          cmake -S hakoniwa-core-pro -B hakoniwa-core-pro/build -A x64 `
+            -DHAKO_CLIENT_OPTION_FILEPATH="$coreOptions" `
+            -DCMAKE_INSTALL_PREFIX="$env:GITHUB_WORKSPACE/core-install" `
+            -DHAKO_CORE_CONFIG_INSTALL_DIR=etc/hakoniwa `
+            -DHAKO_CORE_PRO_BUILD_COMMAND=OFF `
+            -DHAKO_CORE_PRO_BUILD_EXAMPLES=OFF `
+            -DHAKO_CORE_PRO_BUILD_PYTHON_BINDINGS=OFF `
+            -DHAKO_ENABLE_GTEST=OFF
+          cmake --build hakoniwa-core-pro/build --config Release
+          cmake --install hakoniwa-core-pro/build --config Release --prefix "$env:GITHUB_WORKSPACE/core-install"
+
+      - name: Enable Core in the user build manifest
+        shell: pwsh
+        run: |
+          $manifest = Get-Content hakoniwa-build.yaml -Raw
+          $manifest = $manifest.Replace("  hakoniwa_core: false", "  hakoniwa_core: true")
+          $manifest = $manifest.Replace('  hakoniwa_core_root: ""', "  hakoniwa_core_root: `"$($env:GITHUB_WORKSPACE.Replace('\', '/'))/core-install`"")
+          $manifest = $manifest.Replace('  vcpkg_root: ""', '  vcpkg_root: "C:/vcpkg"')
+          Set-Content hakoniwa-build.yaml $manifest
+          Get-Content hakoniwa-build.yaml
+
+      - name: Doctor through hako.py
+        run: python tools/hako.py doctor
+
+      - name: Configure through hako.py
+        run: python tools/hako.py configure
+
+      # This is the regression/reproduction point from hakoniwa-business-pack#47.
+      # Before the upstream package/export issue is fixed, the Core callback/polling
+      # variants are expected to expose the missing-header failure here.
+      - name: Build through hako.py
+        run: python tools/hako.py build --config Release


### PR DESCRIPTION
## Purpose

Preserve the user-facing Windows Core-enabled build path reported by hakoniwa-business-pack PR #47 as an executable integration check.

Related:
- #58
- https://github.com/hakoniwalab/hakoniwa-business-pack/pull/47
- Business Pack candidate: `knowledge/candidates/pdu-endpoint-core-variant-windows-build-missing-include-dir.yaml`
- hakoniwa-core-pro #75 / #76

## What this adds

A separate `hako-core-integration` workflow on `windows-latest` that:

1. installs the current/latest `hakoniwa-core-pro` from `main`,
2. enables `features.hakoniwa_core: true` in the user-facing build manifest,
3. runs the standard operation sequence:

```text
python tools/hako.py doctor
python tools/hako.py configure
python tools/hako.py build
```

The existing direct-CMake `core-variants` workflow is intentionally left unchanged. It verifies the CMake/package contract directly; this workflow verifies the user-facing `hako.py` integration path.

## Reproduction update

The first draft run used `python tools/hako.py build --config Release`, following wording in the Business Pack candidate. Inspection of `tools/hako.py` showed that `--config` means an alternate manifest path, not the CMake Release/Debug configuration. Build type comes from `hakoniwa-build.yaml`.

That first RED was therefore not evidence of a current Core defect. The workflow now uses the actual standard contract: `python tools/hako.py build`.

The deeper Core package/export issue identified by the candidate has also already been fixed upstream by hakoniwa-core-pro #75 and #76. The current run against latest Core is therefore the meaningful regression check:

- if GREEN, preserve this CI and feed the verified resolution/corrected reproduction wording back to Business Pack;
- if RED, diagnose the current log before adding any new Core or Endpoint workaround.

This remains draft until that current-path result is understood.

Refs #58