### PR TITLE
fix: capture the socket error before cleanup in TCP listen setup

### DIFF
--- a/src/comm_tcp.cpp
+++ b/src/comm_tcp.cpp
@@ -138,8 +138,9 @@ HakoPduErrorType TcpComm::raw_open(const std::string& config_path) {
 
         listen_fd_ = create_socket(local_addr_info->ai_family, local_addr_info->ai_socktype, local_addr_info->ai_protocol);
         if (!is_valid_socket(listen_fd_.load())) {
+            const int error_number = last_socket_error();
             free_address_info(local_addr_info);
-            std::cerr << "Failed to create socket: " << socket_error_message(last_socket_error()) << std::endl;
+            std::cerr << "Failed to create socket: " << socket_error_message(error_number) << std::endl;
             return HAKO_PDU_ERR_IO_ERROR;
         }
         if (configure_socket_options(listen_fd_.load(), options_) != HAKO_PDU_ERR_OK) {
@@ -155,15 +156,17 @@ HakoPduErrorType TcpComm::raw_open(const std::string& config_path) {
             return HAKO_PDU_ERR_INVALID_ARGUMENT;
         }
         if (bind_socket(listen_fd_.load(), local_addr_info->ai_addr, local_addr_len) != 0) {
+            const int error_number = last_socket_error();
             raw_close();
             free_address_info(local_addr_info);
-            std::cerr << "Failed to bind socket: " << socket_error_message(last_socket_error()) << std::endl;
+            std::cerr << "Failed to bind socket: " << socket_error_message(error_number) << std::endl;
             return HAKO_PDU_ERR_IO_ERROR;
         }
         if (listen_socket(listen_fd_.load(), options_.backlog) != 0) {
+            const int error_number = last_socket_error();
             raw_close();
             free_address_info(local_addr_info);
-            std::cerr << "Failed to listen on socket: " << socket_error_message(last_socket_error()) << std::endl;
+            std::cerr << "Failed to listen on socket: " << socket_error_message(error_number) << std::endl;
             return HAKO_PDU_ERR_IO_ERROR;
         }
         free_address_info(local_addr_info);

--- a/src/comm_tcp_mux.cpp
+++ b/src/comm_tcp_mux.cpp
@@ -415,8 +415,9 @@ HakoPduErrorType TcpCommMultiplexer::open(const std::string& config_path)
 
     listen_fd_ = create_socket(local_addr_info->ai_family, local_addr_info->ai_socktype, local_addr_info->ai_protocol);
     if (!is_valid_socket(listen_fd_.load())) {
+        const int error_number = last_socket_error();
         free_address_info(local_addr_info);
-        std::cerr << "Failed to create socket: " << socket_error_message(last_socket_error()) << std::endl;
+        std::cerr << "Failed to create socket: " << socket_error_message(error_number) << std::endl;
         return HAKO_PDU_ERR_IO_ERROR;
     }
     if (configure_socket_options_(listen_fd_.load(), options_) != HAKO_PDU_ERR_OK) {
@@ -433,15 +434,17 @@ HakoPduErrorType TcpCommMultiplexer::open(const std::string& config_path)
         return HAKO_PDU_ERR_INVALID_ARGUMENT;
     }
     if (bind_socket(listen_fd_.load(), local_addr_info->ai_addr, local_addr_len) != 0) {
+        const int error_number = last_socket_error();
         close();
         free_address_info(local_addr_info);
-        std::cerr << "Failed to bind socket: " << socket_error_message(last_socket_error()) << std::endl;
+        std::cerr << "Failed to bind socket: " << socket_error_message(error_number) << std::endl;
         return HAKO_PDU_ERR_IO_ERROR;
     }
     if (listen_socket(listen_fd_.load(), options_.backlog) != 0) {
+        const int error_number = last_socket_error();
         close();
         free_address_info(local_addr_info);
-        std::cerr << "Failed to listen on socket: " << socket_error_message(last_socket_error()) << std::endl;
+        std::cerr << "Failed to listen on socket: " << socket_error_message(error_number) << std::endl;
         return HAKO_PDU_ERR_IO_ERROR;
     }
     free_address_info(local_addr_info);


### PR DESCRIPTION
Fixes #62.

## What changed

All three failure branches of the TCP listen setup path now read `last_socket_error()` into a local before any cleanup runs — socket creation, bind, and listen — in both `TcpComm::raw_open()` and `TcpMuxComm`.

Previously the error was read after `raw_close()` / `close()` and `free_address_info()` had already executed. Both `closesocket()` and `freeaddrinfo()` reset the calling thread's Winsock error, so the message reported the successful cleanup rather than the original failure. On a Japanese Windows that produced:

```
Failed to bind socket: この操作を正しく終了しました。
Failed to open PDU Comm: 3
```

— "the operation completed successfully", attached to a message announcing a socket failure.

POSIX is unaffected either way, because a successful `close()` does not clear `errno`. That asymmetry is probably why this survived.

## Measurement

Windows 11 Pro x86_64, MSVC x64/Release, `hakoniwa-pdu-endpoint` at `5e45af8` plus this patch. The same port was deliberately held by another process, the same `hakoniwa-pdu-rpc` contract test was run against both builds, and **only the endpoint DLL differed**:

| | first `Failed to bind socket:` line |
|---|---|
| before | localized text for error code **0** (`ERROR_SUCCESS`) |
| after | localized text for **`WSAEACCES`** (10013) |

The real Winsock error now reaches the reader. (10013 rather than 10048 here because the holding socket was an ordinary listener; either way it is the actual cause instead of a success message.)

Clean build and install both exit 0 with the patch applied (`tools/hako.py build`, then `install` into a fresh prefix with a venv), and `hakoniwa-pdu-rpc` links and builds its contract tests against the patched install.

## Scope

Deliberately narrow. The accept and client-connect paths already read the error immediately after the failing call, with no cleanup in between, so they are untouched. `configure_socket_options` failures print no socket error at all and were left as they are.

## Note

The port collision that led me here is a separate matter — the fixtures and the Business Pack recipe use ports inside the platform's ephemeral range. That is written up in the business-pack knowledge candidates (hakoniwalab/hakoniwa-business-pack#88) and is not addressed by this PR.
