### PR TITLE
Fix Windows TCP shutdown hang

### DIFF
--- a/src/comm_tcp.cpp
+++ b/src/comm_tcp.cpp
@@ -234,9 +234,10 @@ HakoPduErrorType TcpComm::raw_stop() noexcept {
         (void)close_socket(current_listen_fd);
         listen_fd_ = kInvalidSocket;
     }
-    SocketHandle current_client_fd = client_fd_.load();
+    SocketHandle current_client_fd = client_fd_.exchange(kInvalidSocket);
     if (is_valid_socket(current_client_fd)) {
         shutdown_socket(current_client_fd, SocketShutdownMode::ReadWrite);
+        (void)close_socket(current_client_fd);
     }
 
     if (comm_thread_.joinable()) {

--- a/src/comm_tcp_mux.cpp
+++ b/src/comm_tcp_mux.cpp
@@ -141,12 +141,15 @@ protected:
         }
         stopping_ = true;
         is_running_ = false;
-        if (is_valid_socket(fd_)) {
-            shutdown_socket(fd_, SocketShutdownMode::ReadWrite);
+        const SocketHandle current_fd = fd_;
+        if (is_valid_socket(current_fd)) {
+            shutdown_socket(current_fd, SocketShutdownMode::ReadWrite);
+            (void)close_socket(current_fd);
         }
         if (recv_thread_.joinable()) {
             recv_thread_.join();
         }
+        fd_ = kInvalidSocket;
         disconnect_notified_ = false;
         return HAKO_PDU_ERR_OK;
     }


### PR DESCRIPTION
## Summary

- close the connected TCP socket before joining the TCP receive thread
- apply the same shutdown ordering to TCP multiplexer sessions
- invalidate the regular TCP socket atomically, and invalidate the mux session socket after its receive thread has joined

## Problem

Hakoniwa Conductor Light's Windows `smoke manual` test completed startup and invoked its first `hakoctl state` command, but the command process never exited. Python remained blocked in `subprocess.run(...).communicate()` until the workflow was canceled about 35 minutes later.

The RPC operation itself was not the failure point. `hakoctl` performs the RPC and then calls `client.stop()`. Endpoint's TCP stop paths called `shutdown()` and immediately joined the blocking receive thread, while the actual socket `close()` happened only after the join returned. On Windows, `shutdown()` alone did not reliably release the blocking `recv()`, so the join could wait indefinitely.

## Fix

The regular TCP and TCP multiplexer session stop paths now:

1. capture the connected socket handle
2. call `shutdown()`
3. close the socket to release a blocking receive
4. join the receive thread
5. leave the stored socket handle invalid for later cleanup

The branch is a single commit directly on top of `main`, and the final diff is limited to `src/comm_tcp.cpp` and `src/comm_tcp_mux.cpp`.

## Validation

Hakoniwa Conductor Light PR #11 pins this commit and passed its complete cross-platform matrix:

- Ubuntu x64: build, 9 CTests, `smoke auto`, `smoke manual`
- Ubuntu ARM64: build, 9 CTests, `smoke auto`, `smoke manual`
- macOS: build, 9 CTests, `smoke auto`, `smoke manual`
- Windows x64: build, 9 CTests, `smoke auto`, `smoke manual`

The Windows `smoke manual` scenario directly exercises the reported `hakoctl state` process-shutdown hang and now completes successfully.

Endpoint's own CI, core-variant, and Hakoniwa Core integration workflows are also running on the clean final commit.

## Merge order

Merge this Endpoint PR first, then update or merge Hakoniwa Conductor Light PR #11.